### PR TITLE
Fix `matrix` triangular attribute misguide by mirror attribute

### DIFF
--- a/wigglystuff/__init__.py
+++ b/wigglystuff/__init__.py
@@ -71,7 +71,7 @@ class Matrix(anywidget.AnyWidget):
     cols = traitlets.Int(3).tag(sync=True)
     min_value = traitlets.Float(-100.0).tag(sync=True)
     max_value = traitlets.Float(100.0).tag(sync=True)
-    mirror = traitlets.Bool(False).tag(sync=True)
+    triangular = traitlets.Bool(False).tag(sync=True)
     step = traitlets.Float(1.0).tag(sync=True)
     row_names = traitlets.List([]).tag(sync=True)
     col_names = traitlets.List([]).tag(sync=True)

--- a/wigglystuff/static/matrix.js
+++ b/wigglystuff/static/matrix.js
@@ -4,7 +4,7 @@ function render({model, el}){
         cols: model.get("cols"),
         minValue: model.get("min_value"),
         maxValue: model.get("max_value"),
-        isMirrored: model.get("mirror"),
+        isMirrored: model.get("triangular"),
         stepSize: model.get("step"),
         pixelsPerStep: 2,
         rowNames: model.get("row_names"),


### PR DESCRIPTION
Changes to be committed:
	modified:   wigglystuff/__init__.py
	modified:   wigglystuff/static/matrix.js