### PR TITLE
Improve Matrix widget dark mode styling

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -38,3 +38,8 @@ syncs back to Python.
   workflows (`uv pip install -e .` etc.) and the standard library's `pathlib`
   for filesystem paths—mirror those choices in new agents to keep the codebase
   consistent.
+- When styling widgets, support both light and dark themes by defining
+  component-specific CSS variables (see Matrix/SortableList). Scope your
+  defaults to the widget root, mark `color-scheme: light dark`, and provide
+  overrides that respond to `.dark`, `.dark-theme`, or `[data-theme="dark"]`
+  ancestors so notebook-level theme toggles work instantly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dublin",
+  "name": "lusaka",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "anywidget>=0.9.2",
     "mohtml>=0.1.11",
     "numpy",
-    "pandas>=2.3.3",
     "pillow>=12.0.0",
 ]
 
@@ -35,6 +34,7 @@ docs = [
     "mkdocs-include-markdown-plugin>=6.2.1",
     "mike>=2.1.0",
     "black>=24.8.0",
+    "pandas>=2.3.3",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "anywidget>=0.9.2",
     "mohtml>=0.1.11",
     "numpy",
+    "pandas>=2.3.3",
     "pillow>=12.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 
@@ -610,7 +611,8 @@ name = "ipython"
 version = "9.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -1485,7 +1487,8 @@ name = "numpy"
 version = "2.3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/65/21b3bc86aac7b8f2862db1e808f1ea22b028e30a225a34a5ede9bf8678f2/numpy-2.3.5.tar.gz", hash = "sha256:784db1dcdab56bf0517743e746dfb0f885fc68d948aba86eeec2cba234bdf1c0", size = 20584950, upload-time = "2025-11-16T22:52:42.067Z" }
 wheels = [
@@ -1580,6 +1583,68 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/f7/f425a00df4fcc22b292c6895c6831c0c8ae1d9fac1e024d16f98a9ce8749/pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c", size = 11555763, upload-time = "2025-09-29T23:16:53.287Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a", size = 10801217, upload-time = "2025-09-29T23:17:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/03/3fc4a529a7710f890a239cc496fc6d50ad4a0995657dccc1d64695adb9f4/pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1", size = 12148791, upload-time = "2025-09-29T23:17:18.444Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838", size = 12769373, upload-time = "2025-09-29T23:17:35.846Z" },
+    { url = "https://files.pythonhosted.org/packages/df/91/82cc5169b6b25440a7fc0ef3a694582418d875c8e3ebf796a6d6470aa578/pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250", size = 13200444, upload-time = "2025-09-29T23:17:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ae/89b3283800ab58f7af2952704078555fa60c807fff764395bb57ea0b0dbd/pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4", size = 13858459, upload-time = "2025-09-29T23:18:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/85/72/530900610650f54a35a19476eca5104f38555afccda1aa11a92ee14cb21d/pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826", size = 11346086, upload-time = "2025-09-29T23:18:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
 ]
 
 [[package]]
@@ -1904,6 +1969,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/a762be14dae1c3bf280202ba3172020b2b0b4c537f94427435f19c413b72/pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a", size = 17644, upload-time = "2025-11-05T13:36:35.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/25/d9db8be44e205a124f6c98bc0324b2bb149b7431c53877fc6d1038dddaf5/pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3", size = 12195, upload-time = "2025-11-05T13:36:33.183Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -2556,6 +2630,7 @@ dependencies = [
     { name = "mohtml" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas" },
     { name = "pillow" },
 ]
 
@@ -2589,6 +2664,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.1" },
     { name = "mohtml", specifier = ">=0.1.11" },
     { name = "numpy" },
+    { name = "pandas", specifier = ">=2.3.3" },
     { name = "pillow", specifier = ">=12.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2630,7 +2630,6 @@ dependencies = [
     { name = "mohtml" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas" },
     { name = "pillow" },
 ]
 
@@ -2645,6 +2644,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-section-index" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pandas" },
 ]
 test = [
     { name = "pytest" },
@@ -2664,7 +2664,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.1" },
     { name = "mohtml", specifier = ">=0.1.11" },
     { name = "numpy" },
-    { name = "pandas", specifier = ">=2.3.3" },
+    { name = "pandas", marker = "extra == 'docs'", specifier = ">=2.3.3" },
     { name = "pillow", specifier = ">=12.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3" },
 ]

--- a/wigglystuff/static/matrix.css
+++ b/wigglystuff/static/matrix.css
@@ -7,51 +7,85 @@
     padding: 10px;
     position: relative;
     user-select: none;
+    color: var(--matrix-text, #111827);
 }
-.matrix:before, .matrix:after {
+
+.matrix:before,
+.matrix:after {
     content: "";
     position: absolute;
     top: 0;
     bottom: 0;
     width: 2px;
-    background-color: black;
+    background-color: var(--matrix-bracket, #000000);
 }
-.matrix:before { left: 0; }
-.matrix:after { right: 0; }
+
+.matrix:before {
+    left: 0;
+}
+
+.matrix:after {
+    right: 0;
+}
+
 .matrix-row {
     display: flex;
     justify-content: flex-start;
-}
-.matrix-element {
-    width: 3em;
-    height: 1.5em;
-    text-align: center;
-    margin: 0.2em;
-    cursor: ew-resize;
-    color: #0066cc;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.matrix-element::selection {
-    background-color: transparent;
 }
 
 .matrix-wrapper {
     display: inline-block;
     font-family: monospace;
     font-size: 14px;
+    color-scheme: light dark;
+    --matrix-bg: #ffffff;
+    --matrix-text: #111827;
+    --matrix-muted: #4b5563;
+    --matrix-border: rgba(17, 24, 39, 0.15);
+    --matrix-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+    --matrix-accent: #0b74ff;
+    --matrix-static: #6b7280;
+    --matrix-cell-bg: rgba(11, 116, 255, 0.08);
+    --matrix-cell-hover-bg: rgba(11, 116, 255, 0.18);
+    --matrix-cell-static-bg: rgba(15, 23, 42, 0.08);
+    --matrix-bracket: rgba(15, 23, 42, 0.6);
+    --matrix-grid-bg: rgba(243, 244, 246, 0.7);
+    border: 1px solid var(--matrix-border);
+    border-radius: 12px;
+    padding: 10px 12px;
+    background-color: var(--matrix-bg);
+    color: var(--matrix-text);
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: var(--matrix-shadow);
+}
+
+@media (prefers-color-scheme: dark) {
+    .matrix-wrapper {
+        --matrix-bg: #0f172a;
+        --matrix-text: #f3f4f6;
+        --matrix-muted: #c7d2fe;
+        --matrix-border: rgba(148, 163, 184, 0.4);
+        --matrix-shadow: 0 12px 32px rgba(2, 6, 23, 0.65);
+        --matrix-accent: #7dd3fc;
+        --matrix-static: #e2e8f0;
+        --matrix-cell-bg: rgba(148, 163, 184, 0.16);
+        --matrix-cell-hover-bg: rgba(125, 211, 252, 0.35);
+        --matrix-cell-static-bg: rgba(148, 163, 184, 0.12);
+        --matrix-bracket: rgba(148, 163, 184, 0.75);
+        --matrix-grid-bg: rgba(15, 23, 42, 0.75);
+    }
 }
 
 .matrix-grid {
     display: flex;
     align-items: flex-start;
+    color: inherit;
 }
 
 .matrix-column {
     display: flex;
     flex-direction: column;
+    color: inherit;
 }
 
 .matrix-label-column {
@@ -62,9 +96,10 @@
     display: flex;
     position: relative;
     padding: 0 15px;
+    background: var(--matrix-grid-bg, transparent);
+    border-radius: 10px;
 }
 
-/* Matrix brackets */
 .matrix-data-wrapper::before,
 .matrix-data-wrapper::after {
     content: '';
@@ -76,16 +111,16 @@
 
 .matrix-data-wrapper::before {
     left: 3px;
-    border-left: 2px solid black;
-    border-top: 2px solid black;
-    border-bottom: 2px solid black;
+    border-left: 2px solid var(--matrix-bracket, black);
+    border-top: 2px solid var(--matrix-bracket, black);
+    border-bottom: 2px solid var(--matrix-bracket, black);
 }
 
 .matrix-data-wrapper::after {
     right: 3px;
-    border-right: 2px solid black;
-    border-top: 2px solid black;
-    border-bottom: 2px solid black;
+    border-right: 2px solid var(--matrix-bracket, black);
+    border-top: 2px solid var(--matrix-bracket, black);
+    border-bottom: 2px solid var(--matrix-bracket, black);
 }
 
 .matrix-data-column {
@@ -98,18 +133,47 @@
     justify-content: center;
     height: 2em;
     box-sizing: border-box;
+    color: inherit;
 }
 
 .matrix-element {
     width: 3em;
-    margin: 0 0.3em;
+    height: 1.6em;
+    text-align: center;
+    margin: 0.2em;
     cursor: ew-resize;
-    color: #0066cc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--matrix-accent, #0066cc);
+    background-color: var(--matrix-cell-bg, rgba(0, 0, 0, 0.05));
+    border-radius: 0.4em;
+    transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum' 1;
+    min-width: 3em;
+    box-shadow: inset 0 0 0 1px transparent;
+}
+
+.matrix-element:hover,
+.matrix-element:focus-visible {
+    background-color: var(--matrix-cell-hover-bg, rgba(0, 102, 204, 0.2));
+    color: var(--matrix-text, #111827);
+}
+
+.matrix-element:focus-visible {
+    outline: 2px solid var(--matrix-accent, #0066cc);
+    outline-offset: 2px;
+}
+
+.matrix-element::selection {
+    background-color: transparent;
 }
 
 .matrix-element-static {
     cursor: default;
-    color: #666;
+    color: var(--matrix-static, #666666);
+    background-color: var(--matrix-cell-static-bg, rgba(0, 0, 0, 0.05));
 }
 
 .matrix-row-label {
@@ -117,22 +181,21 @@
     min-width: 5em;
     justify-content: flex-end;
     padding-right: 0.5em;
-    font-weight: bold;
-    color: #333;
+    font-weight: 600;
+    color: var(--matrix-muted, #333333);
     white-space: nowrap;
 }
 
 .matrix-col-label {
-    font-weight: bold;
-    color: #333;
+    font-weight: 600;
+    color: var(--matrix-muted, #333333);
     margin-bottom: 5px;
-    width: 3.6em; /* Slightly wider than matrix elements to account for margins */
+    width: 3.6em;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-/* Flexible columns mode */
 .matrix-grid.flexible-columns .matrix-element {
     width: auto;
     min-width: 3em;
@@ -155,14 +218,12 @@
     margin-bottom: 5px;
 }
 
-/* Adjust bracket positioning to exclude headers */
 .matrix-grid:has(.matrix-col-label) .matrix-data-wrapper::before,
 .matrix-grid:has(.matrix-col-label) .matrix-data-wrapper::after {
-    top: calc(2em + 5px); /* Height of header cell + margin */
-    height: calc(100% - 2em - 5px); /* Full height minus header */
+    top: calc(2em + 5px);
+    height: calc(100% - 2em - 5px);
 }
 
-/* If there are no column names, brackets should span full height */
 .matrix-grid:not(:has(.matrix-col-label)) .matrix-data-wrapper::before,
 .matrix-grid:not(:has(.matrix-col-label)) .matrix-data-wrapper::after {
     top: 0;

--- a/wigglystuff/static/matrix.css
+++ b/wigglystuff/static/matrix.css
@@ -59,21 +59,21 @@
     box-shadow: var(--matrix-shadow);
 }
 
-@media (prefers-color-scheme: dark) {
-    .matrix-wrapper {
-        --matrix-bg: #0f172a;
-        --matrix-text: #f3f4f6;
-        --matrix-muted: #c7d2fe;
-        --matrix-border: rgba(148, 163, 184, 0.4);
-        --matrix-shadow: 0 12px 32px rgba(2, 6, 23, 0.65);
-        --matrix-accent: #7dd3fc;
-        --matrix-static: #e2e8f0;
-        --matrix-cell-bg: rgba(148, 163, 184, 0.16);
-        --matrix-cell-hover-bg: rgba(125, 211, 252, 0.35);
-        --matrix-cell-static-bg: rgba(148, 163, 184, 0.12);
-        --matrix-bracket: rgba(148, 163, 184, 0.75);
-        --matrix-grid-bg: rgba(15, 23, 42, 0.75);
-    }
+.dark .matrix-wrapper,
+.dark-theme .matrix-wrapper,
+[data-theme="dark"] .matrix-wrapper {
+    --matrix-bg: #0f172a;
+    --matrix-text: #f3f4f6;
+    --matrix-muted: #c7d2fe;
+    --matrix-border: rgba(148, 163, 184, 0.4);
+    --matrix-shadow: 0 12px 32px rgba(2, 6, 23, 0.65);
+    --matrix-accent: #7dd3fc;
+    --matrix-static: #e2e8f0;
+    --matrix-cell-bg: rgba(148, 163, 184, 0.16);
+    --matrix-cell-hover-bg: rgba(125, 211, 252, 0.35);
+    --matrix-cell-static-bg: rgba(148, 163, 184, 0.12);
+    --matrix-bracket: rgba(148, 163, 184, 0.75);
+    --matrix-grid-bg: rgba(15, 23, 42, 0.75);
 }
 
 .matrix-grid {

--- a/wigglystuff/static/matrix.css
+++ b/wigglystuff/static/matrix.css
@@ -7,7 +7,6 @@
     padding: 10px;
     position: relative;
     user-select: none;
-    color: var(--matrix-text, #111827);
 }
 
 .matrix:before,
@@ -38,42 +37,21 @@
     font-family: monospace;
     font-size: 14px;
     color-scheme: light dark;
-    --matrix-bg: #ffffff;
     --matrix-text: #111827;
-    --matrix-muted: #4b5563;
-    --matrix-border: rgba(17, 24, 39, 0.15);
-    --matrix-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
-    --matrix-accent: #0b74ff;
-    --matrix-static: #6b7280;
-    --matrix-cell-bg: rgba(11, 116, 255, 0.08);
-    --matrix-cell-hover-bg: rgba(11, 116, 255, 0.18);
-    --matrix-cell-static-bg: rgba(15, 23, 42, 0.08);
-    --matrix-bracket: rgba(15, 23, 42, 0.6);
-    --matrix-grid-bg: rgba(243, 244, 246, 0.7);
-    border: 1px solid var(--matrix-border);
-    border-radius: 12px;
-    padding: 10px 12px;
-    background-color: var(--matrix-bg);
-    color: var(--matrix-text);
-    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-    box-shadow: var(--matrix-shadow);
+    --matrix-muted: #333333;
+    --matrix-accent: #0066cc;
+    --matrix-static: #666666;
+    --matrix-bracket: rgba(0, 0, 0, 0.85);
 }
 
 .dark .matrix-wrapper,
 .dark-theme .matrix-wrapper,
 [data-theme="dark"] .matrix-wrapper {
-    --matrix-bg: #0f172a;
     --matrix-text: #f3f4f6;
     --matrix-muted: #c7d2fe;
-    --matrix-border: rgba(148, 163, 184, 0.4);
-    --matrix-shadow: 0 12px 32px rgba(2, 6, 23, 0.65);
     --matrix-accent: #7dd3fc;
     --matrix-static: #e2e8f0;
-    --matrix-cell-bg: rgba(148, 163, 184, 0.16);
-    --matrix-cell-hover-bg: rgba(125, 211, 252, 0.35);
-    --matrix-cell-static-bg: rgba(148, 163, 184, 0.12);
-    --matrix-bracket: rgba(148, 163, 184, 0.75);
-    --matrix-grid-bg: rgba(15, 23, 42, 0.75);
+    --matrix-bracket: rgba(148, 163, 184, 0.85);
 }
 
 .matrix-grid {
@@ -96,8 +74,6 @@
     display: flex;
     position: relative;
     padding: 0 15px;
-    background: var(--matrix-grid-bg, transparent);
-    border-radius: 10px;
 }
 
 .matrix-data-wrapper::before,
@@ -138,32 +114,14 @@
 
 .matrix-element {
     width: 3em;
-    height: 1.6em;
+    height: 1.5em;
     text-align: center;
     margin: 0.2em;
     cursor: ew-resize;
+    color: var(--matrix-accent, #0066cc);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--matrix-accent, #0066cc);
-    background-color: var(--matrix-cell-bg, rgba(0, 0, 0, 0.05));
-    border-radius: 0.4em;
-    transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
-    font-variant-numeric: tabular-nums;
-    font-feature-settings: 'tnum' 1;
-    min-width: 3em;
-    box-shadow: inset 0 0 0 1px transparent;
-}
-
-.matrix-element:hover,
-.matrix-element:focus-visible {
-    background-color: var(--matrix-cell-hover-bg, rgba(0, 102, 204, 0.2));
-    color: var(--matrix-text, #111827);
-}
-
-.matrix-element:focus-visible {
-    outline: 2px solid var(--matrix-accent, #0066cc);
-    outline-offset: 2px;
 }
 
 .matrix-element::selection {
@@ -173,7 +131,6 @@
 .matrix-element-static {
     cursor: default;
     color: var(--matrix-static, #666666);
-    background-color: var(--matrix-cell-static-bg, rgba(0, 0, 0, 0.05));
 }
 
 .matrix-row-label {
@@ -181,13 +138,13 @@
     min-width: 5em;
     justify-content: flex-end;
     padding-right: 0.5em;
-    font-weight: 600;
+    font-weight: bold;
     color: var(--matrix-muted, #333333);
     white-space: nowrap;
 }
 
 .matrix-col-label {
-    font-weight: 600;
+    font-weight: bold;
     color: var(--matrix-muted, #333333);
     margin-bottom: 5px;
     width: 3.6em;


### PR DESCRIPTION
Improves the Matrix widget styling with theme-aware CSS tokens so it looks correct in dark mode. Also updates the package-lock metadata to use the Lusaka workspace name.