### PR TITLE
Add widget demos and export improvements

### DIFF
--- a/demos/colorpicker.py
+++ b/demos/colorpicker.py
@@ -1,0 +1,62 @@
+import marimo
+
+__generated_with = "0.18.1"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from wigglystuff import ColorPicker
+
+    picker = mo.ui.anywidget(ColorPicker(color="#0ea5e9"))
+    return mo, picker
+
+
+@app.cell
+def _(picker):
+    picker
+    return
+
+
+@app.cell
+def _(mo, picker):
+    r, g, b = picker.rgb
+
+    mo.vstack(
+        [
+            mo.md(
+                f"You picked **{picker.color}** which is **RGB {r}, {g}, {b}**."
+            ),
+            mo.md(
+                f"<div style='width:96px;height:96px;border-radius:0.75rem;"
+                f"border:1px solid #d4d4d8;background:{picker.color};'></div>"
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo, picker):
+    import random
+
+    def randomize(_):
+        picker.color = f"#{random.randint(0, 0xFFFFFF):06x}"
+
+    mo.callout.info("Click to jump to a random color:")
+    mo.ui.button(label="Surprise me", kind="primary", on_click=randomize)
+    return
+
+
+@app.cell
+def _(mo, picker):
+    def log_change(change):
+        mo.log.info("color changed to %s", change["new"])
+
+    picker.observe(log_change, names="color")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/demos/copytoclipboard.py
+++ b/demos/copytoclipboard.py
@@ -1,0 +1,47 @@
+import marimo
+
+__generated_with = "0.18.1"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from wigglystuff import CopyToClipboard
+
+    default_snippet = "pip install wigglystuff"
+    widget = mo.ui.anywidget(CopyToClipboard(text_to_copy=default_snippet))
+    editor = mo.ui.text_area(label="Text to copy", value=default_snippet)
+    return editor, mo, widget
+
+
+@app.cell
+def _(widget):
+    widget
+    return
+
+
+@app.cell
+def _(editor):
+    editor
+    return
+
+
+@app.cell
+def _(editor, widget):
+    widget.text_to_copy = editor.value
+    return
+
+
+@app.cell
+def _(mo, widget):
+    preview = widget.text_to_copy
+    truncated = preview if len(preview) < 80 else preview[:77] + "..."
+
+    mo.callout.info("Click the button to copy the payload below:")
+    mo.md(f"```text\n{truncated}\n```")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/demos/gamepad.py
+++ b/demos/gamepad.py
@@ -1,0 +1,85 @@
+import marimo
+
+__generated_with = "0.18.1"
+app = marimo.App(width="columns")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from wigglystuff import GamepadWidget
+
+    pad = mo.ui.anywidget(GamepadWidget())
+    return mo, pad
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Listen to browser gamepad events
+
+    This widget streams button presses, d-pad status, and analog stick axes.
+    Plug in a controller (or pair a Bluetooth one), press any button, and you should see data below.
+    """)
+    return
+
+
+@app.cell
+def _(pad):
+    pad
+    return
+
+
+@app.cell
+def _(mo, pad):
+    axes = pad.axes if pad.axes else [0.0, 0.0, 0.0, 0.0]
+    left_axes = tuple(round(val, 2) for val in axes[:2])
+    right_axes = tuple(round(val, 2) for val in axes[2:])
+
+    dpad_directions = [
+        symbol
+        for flag, symbol in [
+            (pad.dpad_up, "↑"),
+            (pad.dpad_down, "↓"),
+            (pad.dpad_left, "←"),
+            (pad.dpad_right, "→"),
+        ]
+        if flag
+    ]
+
+    last_button = pad.current_button_press if pad.current_button_press >= 0 else "—"
+    current_ts = pad.current_timestamp or "—"
+    previous_ts = pad.previous_timestamp or "—"
+
+    mo.vstack(
+        [
+            mo.md(
+                f"**Last button:** `{last_button}` &nbsp;&nbsp;|&nbsp;&nbsp; "
+                f"**Last change (ms):** `{current_ts}` &nbsp;&nbsp;|&nbsp;&nbsp; "
+                f"**Previous:** `{previous_ts}`"
+            ),
+            mo.md(
+                f"**Sticks** &nbsp; Left: `{left_axes}` &nbsp; Right: `{right_axes}`"
+            ),
+            mo.md(
+                "**D-pad:** "
+                + (" ".join(dpad_directions) if dpad_directions else "`—` (tap the arrows)")
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo, pad):
+    def log_button(change):
+        new = change.get("new", -1)
+        if new >= 0:
+            mo.log.info("button %s pressed", new)
+
+    pad.observe(log_button, names="current_button_press")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/demos/keystroke.py
+++ b/demos/keystroke.py
@@ -1,0 +1,85 @@
+import marimo
+
+__generated_with = "0.18.1"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from wigglystuff import KeystrokeWidget
+
+    listener = mo.ui.anywidget(KeystrokeWidget())
+    return listener, mo
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Capture shortcuts from the browser
+
+    Click the widget, then press any key combination (e.g. `Ctrl + Shift + P`).
+    The latest shortcut is synced to Python through the `last_key` trait.
+    """)
+    return
+
+
+@app.cell
+def _(listener):
+    listener
+    return
+
+
+@app.cell
+def _(listener, mo):
+    info = listener.last_key or {}
+
+    modifiers = [
+        label
+        for key, label in [
+            ("ctrlKey", "Ctrl"),
+            ("shiftKey", "Shift"),
+            ("altKey", "Alt"),
+            ("metaKey", "Meta"),
+        ]
+        if info.get(key)
+    ]
+
+    shortcut = " + ".join(modifiers + [info.get("key", "—")]).strip(" + ")
+    rows = {
+        "Shortcut": shortcut or "—",
+        "Code": info.get("code", "—"),
+        "Timestamp": info.get("timestamp", "—"),
+    }
+
+    mo.callout.info("Latest keyboard event from the browser:")
+    mo.md("\n".join(f"- **{label}:** `{value}`" for label, value in rows.items()))
+    return
+
+
+@app.cell
+def _(listener, mo):
+    def log_shortcut(change):
+        payload = change.get("new") or {}
+        combo = " + ".join(
+            part
+            for part in [
+                *(label for key, label in [
+                    ("ctrlKey", "Ctrl"),
+                    ("shiftKey", "Shift"),
+                    ("altKey", "Alt"),
+                    ("metaKey", "Meta"),
+                ]
+                if payload.get(key)),
+                payload.get("key"),
+            ]
+            if part
+        )
+        mo.log.info("shortcut -> %s", combo or "(none)")
+
+    listener.observe(log_shortcut, names="last_key")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/demos/matrix.py
+++ b/demos/matrix.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.18.1"
+__generated_with = "0.18.3"
 app = marimo.App(width="large")
 
 
@@ -13,7 +13,7 @@ def _():
 
     mean_widget = mo.ui.anywidget(Matrix(rows=1, cols=2, step=0.1))
     cov_widget = mo.ui.anywidget(Matrix(matrix=np.eye(2), mirror=True, step=0.05))
-    return cov_widget, mean_widget, mo, np, pd
+    return cov_widget, mean_widget
 
 
 @app.cell
@@ -29,28 +29,14 @@ def _(cov_widget):
 
 
 @app.cell
-def _(mean_widget, mo, np):
-    mean = np.array(mean_widget.matrix).reshape(-1)
-    mo.callout.tip(
-        f"Mean vector = [{mean[0]:.2f}, {mean[1]:.2f}] (editable via the first matrix)"
-    )
+def _(mean_widget):
+    mean_widget.matrix
     return
 
 
 @app.cell
-def _(cov_widget, mo, np):
-    cov = np.array(cov_widget.matrix).reshape(2, 2)
-    mo.callout.info(
-        f"Covariance matrix = {cov.tolist()}"
-    )
-    return cov
-
-
-@app.cell
-def _(cov, mean_widget, mo, np, pd):
-    samples = np.random.multivariate_normal(np.array(mean_widget.matrix).reshape(-1), cov, 500)
-    df = pd.DataFrame(samples, columns=["x", "y"])
-    mo.table(df.head())
+def _(cov_widget):
+    cov_widget.matrix
     return
 
 

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -31,5 +31,9 @@ hide:
 - [EdgeDraw](reference/edge-draw.md) [(demo)](examples/edgedraw/index.html) manipulates graphs directly, surfacing adjacency data for algorithms.
 - [SortableList](reference/sortable-list.md) [(demo)](examples/sortlist/index.html) is a UX-friendly list manager, with add/remove/edit support.
 - [WebkitSpeechToTextWidget](reference/talk.md) [(demo)](examples/talk/index.html) brings speech control to notebooks with simple event hooks.
+- [KeystrokeWidget](reference/keystroke.md) [(demo)](examples/keystroke/index.html) captures shortcuts with modifier metadata so you can wire notebook hotkeys.
+- [GamepadWidget](reference/gamepad.md) [(demo)](examples/gamepad/index.html) streams controller axes, d-pad directions, and button presses for playful control schemes.
+- [ColorPicker](reference/color-picker.md) [(demo)](examples/colorpicker/index.html) streams both hex and RGB values for live theming or palette capture.
+- [CopyToClipboard](reference/copy-to-clipboard.md) [(demo)](examples/copytoclipboard/index.html) offers a one-click button that copies any string payload to the OS clipboard.
 
 Each widget page embeds a marimo-powered html-wasm export and links back to the exact notebook that generated the demo, so you can open the original `.py` file and rerun it locally.

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -25,15 +25,15 @@ hide:
 
 ## What you can build
 
-- [Slider2D](reference/slider2d.md) [(demo)](examples/slider2d/index.html) exposes `x` and `y` in real time for optimization, controls, or gamepads.
-- [Matrix](reference/matrix.md) [(demo)](examples/matrix/index.html) toggles mirroring, clamps steps, and streams eigen-updates.
-- [Paint](reference/paint.md) [(demo)](examples/paint/index.html) ships a PIL surface so you can remix doodles, annotate images, and hand data to multimodal LLMs.
-- [EdgeDraw](reference/edge-draw.md) [(demo)](examples/edgedraw/index.html) manipulates graphs directly, surfacing adjacency data for algorithms.
-- [SortableList](reference/sortable-list.md) [(demo)](examples/sortlist/index.html) is a UX-friendly list manager, with add/remove/edit support.
-- [WebkitSpeechToTextWidget](reference/talk.md) [(demo)](examples/talk/index.html) brings speech control to notebooks with simple event hooks.
-- [KeystrokeWidget](reference/keystroke.md) [(demo)](examples/keystroke/index.html) captures shortcuts with modifier metadata so you can wire notebook hotkeys.
-- [GamepadWidget](reference/gamepad.md) [(demo)](examples/gamepad/index.html) streams controller axes, d-pad directions, and button presses for playful control schemes.
-- [ColorPicker](reference/color-picker.md) [(demo)](examples/colorpicker/index.html) streams both hex and RGB values for live theming or palette capture.
+- [Slider2D](examples/slider2d/index.html) [(API)](reference/slider2d.md) exposes `x` and `y` in real time for optimization, controls, or gamepads.
+- [Matrix](examples/matrix/index.html) [(API)](reference/matrix.md) toggles mirroring, clamps steps, and streams eigen-updates.
+- [Paint](examples/paint/index.html) [(API)](reference/paint.md) ships a PIL surface so you can remix doodles, annotate images, and hand data to multimodal LLMs.
+- [EdgeDraw](examples/edgedraw/index.html) [(API)](reference/edge-draw.md) manipulates graphs directly, surfacing adjacency data for algorithms.
+- [SortableList](examples/sortlist/index.html) [(API)](reference/sortable-list.md) is a UX-friendly list manager, with add/remove/edit support.
+- [WebkitSpeechToTextWidget](examples/talk/index.html) [(API)](reference/talk.md) brings speech control to notebooks with simple event hooks.
+- [KeystrokeWidget](examples/keystroke/index.html) [(API)](reference/keystroke.md) captures shortcuts with modifier metadata so you can wire notebook hotkeys.
+- [GamepadWidget](examples/gamepad/index.html) [(API)](reference/gamepad.md) streams controller axes, d-pad directions, and button presses for playful control schemes.
+- [ColorPicker](examples/colorpicker/index.html) [(API)](reference/color-picker.md) streams both hex and RGB values for live theming or palette capture.
 - [CopyToClipboard](examples/copytoclipboard/index.html) [(API)](reference/copy-to-clipboard.md) offers a one-click button that copies any string payload to the OS clipboard.
 
 Each widget page embeds a marimo-powered html-wasm export and links back to the exact notebook that generated the demo, so you can open the original `.py` file and rerun it locally.

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -34,6 +34,6 @@ hide:
 - [KeystrokeWidget](reference/keystroke.md) [(demo)](examples/keystroke/index.html) captures shortcuts with modifier metadata so you can wire notebook hotkeys.
 - [GamepadWidget](reference/gamepad.md) [(demo)](examples/gamepad/index.html) streams controller axes, d-pad directions, and button presses for playful control schemes.
 - [ColorPicker](reference/color-picker.md) [(demo)](examples/colorpicker/index.html) streams both hex and RGB values for live theming or palette capture.
-- [CopyToClipboard](reference/copy-to-clipboard.md) [(demo)](examples/copytoclipboard/index.html) offers a one-click button that copies any string payload to the OS clipboard.
+- [CopyToClipboard](examples/copytoclipboard/index.html) [(API)](reference/copy-to-clipboard.md) offers a one-click button that copies any string payload to the OS clipboard.
 
 Each widget page embeds a marimo-powered html-wasm export and links back to the exact notebook that generated the demo, so you can open the original `.py` file and rerun it locally.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dublin",
+  "name": "abuja",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.1"
+version = "0.2.3"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -17,7 +17,7 @@ dependencies = [
     "anywidget>=0.9.2",
     "mohtml>=0.1.11",
     "numpy",
-    "pillow>=12.0.0",
+    "pillow",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2549,7 +2549,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/uv.lock
+++ b/uv.lock
@@ -2549,7 +2549,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
@@ -2589,7 +2589,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.1" },
     { name = "mohtml", specifier = ">=0.1.11" },
     { name = "numpy" },
-    { name = "pillow", specifier = ">=12.0.0" },
+    { name = "pillow" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3" },
 ]
 provides-extras = ["test", "docs"]


### PR DESCRIPTION
Adds marimo demos for ColorPicker, CopyToClipboard, KeystrokeWidget, and GamepadWidget and links them from the docs homepage. Updates the demo export script with a --force flag plus skip-if-fresh behavior and bumps the project metadata. Simplifies the Matrix demo to rely entirely on the widget controls. Docs build: 	docs command: uv run mkdocs build -f mkdocs.yml