### PR TITLE
Ensure docs-serve builds demos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ docs:
 docs-demos:
 	uv run python scripts/export_marimo_demos.py
 
-docs-serve:
+docs-serve: docs-demos
 	uv run mkdocs serve -f mkdocs.yml
 
 docs-build: docs-demos

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "lusaka",
+  "name": "madison",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Adds docs-demos as a prerequisite for docs-serve so mkdocs serve runs without strict link failures. Also updates package-lock.json to use the madison package name.