### PR TITLE
Fix matrix demo pyodide export error

### DIFF
--- a/demos/matrix.py
+++ b/demos/matrix.py
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "0.18.2"
-app = marimo.App(width="large")
+app = marimo.App(width="full")
 
 
 @app.cell

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "wigglystuff",
+  "name": "managua",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Fixed `msgspec.ValidationError` when exporting matrix demo to pyodide by using valid enum value
- Changed app width from invalid `"large"` to `"full"`

## Test plan
- Verify the matrix demo exports successfully to pyodide on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)