### PR TITLE
Docs: dedupe widget docstrings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "davao",
+  "name": "mogadishu",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/wigglystuff/cell_tour.py
+++ b/wigglystuff/cell_tour.py
@@ -6,23 +6,8 @@ from .driver_tour import DriverTour
 class CellTour(DriverTour):
     """Simplified tour widget for marimo notebooks.
 
-    A friendlier API for creating guided tours that targets cells by index or name.
-
-    Parameters
-    ----------
-    steps:
-        Sequence of step dictionaries. Each step should have either:
-        - cell: int, 0-indexed cell number to highlight, OR
-        - cell_name: str, the data-cell-name attribute of the cell
-        Plus:
-        - title: str, popover title
-        - description: str, popover description
-        - position: str, optional popover position (default "bottom")
-    auto_start:
-        If True, tour starts automatically when widget is rendered.
-        If False (default), shows a "Start Tour" button.
-    show_progress:
-        If True (default), displays progress indicator like "Step 2 of 5".
+    Wraps ``DriverTour`` with cell-aware step helpers so you can reference
+    marimo cells by index or `data-cell-name` attributes.
 
     Examples
     --------

--- a/wigglystuff/color_picker.py
+++ b/wigglystuff/color_picker.py
@@ -6,14 +6,7 @@ import traitlets
 
 
 class ColorPicker(anywidget.AnyWidget):
-    """Simple color picker that exposes RGB values.
-
-    Parameters
-    ----------
-    color:
-        Optional ``#RRGGBB`` hex string used for the initial value. Defaults to
-        black (``#000000``) when not provided.
-    """
+    """Simple color picker syncing a ``#RRGGBB`` hex value back to Python."""
 
     _esm = Path(__file__).parent / "static" / "colorpicker.js"
     color = traitlets.Unicode("#000000").tag(sync=True)

--- a/wigglystuff/copy_to_clipboard.py
+++ b/wigglystuff/copy_to_clipboard.py
@@ -6,14 +6,7 @@ import traitlets
 
 
 class CopyToClipboard(anywidget.AnyWidget):
-    """Button that copies provided text to the clipboard.
-
-    Parameters
-    ----------
-    text_to_copy:
-        Initial text payload placed behind the button. Defaults to an empty
-        string.
-    """
+    """Button widget that copies the provided ``text_to_copy`` payload."""
 
     text_to_copy = traitlets.Unicode("").tag(sync=True)
     _esm = Path(__file__).parent / "static" / "copybutton.js"

--- a/wigglystuff/driver_tour.py
+++ b/wigglystuff/driver_tour.py
@@ -6,27 +6,10 @@ import traitlets
 
 
 class DriverTour(anywidget.AnyWidget):
-    """Interactive guided tour widget using Driver.js.
+    """Interactive guided tour widget powered by Driver.js overlays.
 
-    Creates product tours and guided highlights for notebook elements as an
-    alternative to markdown documentation. Define tour steps with CSS selectors
-    and popovers to guide users through your notebook.
-
-    Parameters
-    ----------
-    steps:
-        Sequence of tour step dictionaries. Each step should have:
-        - element: CSS selector string (optional, can be None for overlay-only)
-        - popover: dict with title, description, and optional position
-    auto_start:
-        If True, tour starts automatically when widget is rendered.
-        If False (default), shows a "Start Tour" button.
-    show_progress:
-        If True (default), displays progress indicator like "Step 2 of 5".
-    active:
-        Read-only flag indicating if tour is currently running.
-    current_step:
-        Read-only index of the current step in the tour.
+    Define CSS selector-based steps with popovers to guide notebook readers,
+    optionally auto-starting the experience and surfacing progress indicators.
 
     Examples
     --------

--- a/wigglystuff/edge_draw.py
+++ b/wigglystuff/edge_draw.py
@@ -7,15 +7,7 @@ import traitlets
 
 
 class EdgeDraw(anywidget.AnyWidget):
-    """Widget for drawing edges between named nodes.
-
-    Parameters
-    ----------
-    names:
-        Ordered list of node labels to display.
-    height, width:
-        Canvas dimensions in CSS pixels. Defaults are 400x600.
-    """
+    """Sketch node/link diagrams and sync edges as adjacency-friendly data."""
 
     _esm = Path(__file__).parent / "static" / "edgedraw.js"
     _css = Path(__file__).parent / "static" / "edgedraw.css"

--- a/wigglystuff/matrix.py
+++ b/wigglystuff/matrix.py
@@ -7,26 +7,7 @@ import traitlets
 
 
 class Matrix(anywidget.AnyWidget):
-    """Matrix editor widget with validation helpers.
-
-    Parameters
-    ----------
-    matrix:
-        Optional 2D list used to seed the widget. When omitted, a matrix filled
-        with the midpoint of ``min_value``/``max_value`` is created.
-    rows, cols:
-        Declared matrix shape when ``matrix`` is not provided. Defaults to 3x3.
-    min_value, max_value:
-        Bounds enforced on all editable cells.
-    triangular:
-        When ``True`` only the upper triangle is editable.
-    row_names, col_names:
-        Optional labels for rows/columns. Length must match ``rows``/``cols``.
-    static:
-        If ``True`` the grid is read-only.
-    flexible_cols:
-        If ``True`` the front-end allows column insertion/removal.
-    """
+    """Spreadsheet-like numeric editor with bounds, naming, and symmetry helpers."""
 
     _esm = Path(__file__).parent / "static" / "matrix.js"
     _css = Path(__file__).parent / "static" / "matrix.css"

--- a/wigglystuff/paint.py
+++ b/wigglystuff/paint.py
@@ -79,19 +79,7 @@ def input_to_pil(input_data: Union[str, Path, "Image.Image", bytes, None]):
 
 
 class Paint(anywidget.AnyWidget):
-    """Notebook-friendly paint widget with MS Paint style tools.
-
-    Parameters
-    ----------
-    height, width:
-        Canvas dimensions in pixels. Defaults to ``DEFAULT_HEIGHT``/``DEFAULT_WIDTH``.
-    store_background:
-        If ``True`` the widget keeps the background layer when erasing.
-    init_image:
-        Optional image-like object (path, URL, bytes, PIL image, or base64 data)
-        used to seed the canvas. When provided the widget infers width from the
-        image unless ``height`` is explicitly set.
-    """
+    """Notebook-friendly paint widget with MS Paint style tools and PIL helpers."""
 
     _esm = Path(__file__).parent / "static" / "paint.js"
     _css = Path(__file__).parent / "static" / "paint.css"

--- a/wigglystuff/slider2d.py
+++ b/wigglystuff/slider2d.py
@@ -8,15 +8,8 @@ import traitlets
 class Slider2D(anywidget.AnyWidget):
     """Two dimensional slider for simultaneous adjustments.
 
-    Parameters
-    ----------
-    x, y:
-        Initial slider coordinates.
-    width, height:
-        Canvas size in pixels. Defaults to 400x400.
-    x_bounds, y_bounds:
-        Tuples of floats defining the minimum and maximum allowed values for
-        each axis.
+    Emits synchronized ``x``/``y`` floats that stay within configurable bounds
+    while rendering to a pixel canvas sized via ``width``/``height``.
     """
 
     _esm = Path(__file__).parent / "static" / "2dslider.js"

--- a/wigglystuff/sortable_list.py
+++ b/wigglystuff/sortable_list.py
@@ -6,18 +6,7 @@ import traitlets
 
 
 class SortableList(anywidget.AnyWidget):
-    """Interactive sortable list with optional editing capabilities.
-
-    Parameters
-    ----------
-    value:
-        Initial sequence of strings displayed in the list.
-    addable, removable, editable:
-        Feature flags that enable UI controls for inserting, removing, or
-        editing items respectively. Disabled by default.
-    label:
-        Optional caption displayed above the list.
-    """
+    """Drag-and-drop list widget with optional add/remove/edit affordances."""
 
     _esm = Path(__file__).parent / "static" / "sortable-list.js"
     _css = Path(__file__).parent / "static" / "sortable-list.css"

--- a/wigglystuff/tangle.py
+++ b/wigglystuff/tangle.py
@@ -6,24 +6,7 @@ import traitlets
 
 
 class TangleSlider(anywidget.AnyWidget):
-    """Slider inspired by Bret Victor's Tangle UI.
-
-    Parameters
-    ----------
-    amount:
-        Initial value. Defaults to the midpoint between ``min_value`` and
-        ``max_value`` when omitted.
-    min_value, max_value:
-        Range boundaries for the slider.
-    step:
-        Value increment applied per interaction tick.
-    pixels_per_step:
-        How many drag pixels correspond to one ``step``.
-    prefix, suffix:
-        Optional strings rendered before/after the numeric display.
-    digits:
-        Number of decimal places to show.
-    """
+    """Inline slider inspired by Bret Victor's Tangle UI."""
 
     _esm = Path(__file__).parent / "static" / "tangle-slider.js"
     amount = traitlets.Float(0.0).tag(sync=True)
@@ -76,13 +59,7 @@ class TangleSlider(anywidget.AnyWidget):
 
 
 class TangleChoice(anywidget.AnyWidget):
-    """Choice widget inspired by Tangle.
-
-    Parameters
-    ----------
-    choices:
-        Sequence of at least two labels. The widget starts on ``choices[1]``.
-    """
+    """Inline choice widget that cycles through labeled options."""
 
     _esm = Path(__file__).parent / "static" / "tangle-choice.js"
     choice = traitlets.Unicode("").tag(sync=True)
@@ -101,13 +78,7 @@ class TangleChoice(anywidget.AnyWidget):
 
 
 class TangleSelect(anywidget.AnyWidget):
-    """Dropdown select widget inspired by Tangle.
-
-    Parameters
-    ----------
-    choices:
-        Sequence of at least two labels. The widget defaults to ``choices[0]``.
-    """
+    """Dropdown-based take on the Tangle choice pattern."""
 
     _esm = Path(__file__).parent / "static" / "tangle-select.js"
     choice = traitlets.Unicode("").tag(sync=True)


### PR DESCRIPTION
Reworded each widget docstring to remove duplicated parameter listings now handled by mkdocstrings. Keeps the API reference concise while preserving helpful summaries.