### PR TITLE
Add docstring examples and fix docs styling

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,12 +23,9 @@ theme:
     - search.highlight
     - navigation.instant
   palette:
-    - scheme: default
-      primary: grey
-      accent: blue grey
-    - scheme: slate
-      primary: grey
-      accent: blue grey
+    scheme: default
+    primary: grey
+    accent: blue grey
   font:
     text: "PT Sans"
     code: "Fira Mono"
@@ -47,7 +44,6 @@ nav:
       - CopyToClipboard: reference/copy-to-clipboard.md
       - Tangle Widgets: reference/tangle.md
       - GamepadWidget: reference/gamepad.md
-      - DriverTour: reference/driver-tour.md
       - CellTour: reference/cell-tour.md
 plugins:
   - search

--- a/mkdocs/reference/driver-tour.md
+++ b/mkdocs/reference/driver-tour.md
@@ -1,3 +1,0 @@
-# DriverTour API
-
-::: wigglystuff.driver_tour.DriverTour

--- a/mkdocs/reference/index.md
+++ b/mkdocs/reference/index.md
@@ -13,5 +13,4 @@ Browse widget-specific reference pages below. Each page is generated automatical
 - [CopyToClipboard](copy-to-clipboard.md)
 - [Tangle widgets](tangle.md)
 - [GamepadWidget](gamepad.md)
-- [DriverTour](driver-tour.md)
 - [CellTour](cell-tour.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mogadishu",
+  "name": "riga",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/uv.lock
+++ b/uv.lock
@@ -2668,17 +2668,15 @@ name = "wigglystuff"
 version = "0.2.4"
 source = { editable = "." }
 dependencies = [
-    { name = "altair" },
     { name = "anywidget" },
-    { name = "mohtml" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
-    { name = "polars" },
 ]
 
 [package.optional-dependencies]
 docs = [
+    { name = "altair" },
     { name = "black" },
     { name = "marimo" },
     { name = "mike" },
@@ -2688,7 +2686,9 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-section-index" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "mohtml" },
     { name = "pandas" },
+    { name = "polars" },
 ]
 test = [
     { name = "pytest" },
@@ -2696,7 +2696,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altair", specifier = ">=6.0.0" },
+    { name = "altair", marker = "extra == 'docs'", specifier = ">=6.0.0" },
     { name = "anywidget", specifier = ">=0.9.2" },
     { name = "black", marker = "extra == 'docs'", specifier = ">=24.8.0" },
     { name = "marimo", marker = "extra == 'docs'", specifier = ">=0.18.0" },
@@ -2707,11 +2707,11 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
     { name = "mkdocs-section-index", marker = "extra == 'docs'", specifier = ">=0.3.6" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.1" },
-    { name = "mohtml", specifier = ">=0.1.11" },
+    { name = "mohtml", marker = "extra == 'docs'", specifier = ">=0.1.11" },
     { name = "numpy" },
     { name = "pandas", marker = "extra == 'docs'", specifier = ">=2.3.3" },
     { name = "pillow" },
-    { name = "polars", specifier = ">=1.36.1" },
+    { name = "polars", marker = "extra == 'docs'", specifier = ">=1.36.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3" },
 ]
 provides-extras = ["test", "docs"]

--- a/wigglystuff/cell_tour.py
+++ b/wigglystuff/cell_tour.py
@@ -9,20 +9,26 @@ class CellTour(DriverTour):
     Wraps ``DriverTour`` with cell-aware step helpers so you can reference
     marimo cells by index or `data-cell-name` attributes.
 
-    Examples
-    --------
-    >>> # Using cell indices
-    >>> tour = CellTour(steps=[
-    ...     {"cell": 0, "title": "Imports", "description": "Load libraries"},
-    ...     {"cell": 2, "title": "Processing", "description": "Data transformation"},
-    ... ])
+    Examples:
+        Using cell indices:
 
-    >>> # Using cell names (requires naming cells in marimo)
-    >>> tour = CellTour(steps=[
-    ...     {"cell_name": "imports", "title": "Imports", "description": "Load libraries"},
-    ...     {"cell_name": "process", "title": "Processing", "description": "Transform data"},
-    ... ])
-    >>> tour
+        ```python
+        tour = CellTour(steps=[
+            {"cell": 0, "title": "Imports", "description": "Load libraries"},
+            {"cell": 2, "title": "Processing", "description": "Data transformation"},
+        ])
+        tour
+        ```
+
+        Using cell names (requires naming cells in marimo):
+
+        ```python
+        tour = CellTour(steps=[
+            {"cell_name": "imports", "title": "Imports", "description": "Load libraries"},
+            {"cell_name": "process", "title": "Processing", "description": "Transform data"},
+        ])
+        tour
+        ```
     """
 
     def __init__(

--- a/wigglystuff/color_picker.py
+++ b/wigglystuff/color_picker.py
@@ -6,7 +6,14 @@ import traitlets
 
 
 class ColorPicker(anywidget.AnyWidget):
-    """Simple color picker syncing a ``#RRGGBB`` hex value back to Python."""
+    """Simple color picker syncing a ``#RRGGBB`` hex value back to Python.
+
+    Examples:
+        ```python
+        picker = ColorPicker(color="#ff5733")
+        picker
+        ```
+    """
 
     _esm = Path(__file__).parent / "static" / "colorpicker.js"
     color = traitlets.Unicode("#000000").tag(sync=True)

--- a/wigglystuff/copy_to_clipboard.py
+++ b/wigglystuff/copy_to_clipboard.py
@@ -6,7 +6,14 @@ import traitlets
 
 
 class CopyToClipboard(anywidget.AnyWidget):
-    """Button widget that copies the provided ``text_to_copy`` payload."""
+    """Button widget that copies the provided ``text_to_copy`` payload.
+
+    Examples:
+        ```python
+        button = CopyToClipboard(text_to_copy="Hello, world!")
+        button
+        ```
+    """
 
     text_to_copy = traitlets.Unicode("").tag(sync=True)
     _esm = Path(__file__).parent / "static" / "copybutton.js"

--- a/wigglystuff/driver_tour.py
+++ b/wigglystuff/driver_tour.py
@@ -10,27 +10,6 @@ class DriverTour(anywidget.AnyWidget):
 
     Define CSS selector-based steps with popovers to guide notebook readers,
     optionally auto-starting the experience and surfacing progress indicators.
-
-    Examples
-    --------
-    >>> tour = DriverTour(steps=[
-    ...     {
-    ...         "element": "#cell-1",
-    ...         "popover": {
-    ...             "title": "Load Data",
-    ...             "description": "This cell imports the dataset",
-    ...             "position": "bottom"
-    ...         }
-    ...     },
-    ...     {
-    ...         "element": "#cell-2",
-    ...         "popover": {
-    ...             "title": "Process Data",
-    ...             "description": "Here we clean and transform the data"
-    ...         }
-    ...     }
-    ... ])
-    >>> tour
     """
 
     _esm = Path(__file__).parent / "static" / "driver-tour.js"

--- a/wigglystuff/edge_draw.py
+++ b/wigglystuff/edge_draw.py
@@ -7,7 +7,14 @@ import traitlets
 
 
 class EdgeDraw(anywidget.AnyWidget):
-    """Sketch node/link diagrams and sync edges as adjacency-friendly data."""
+    """Sketch node/link diagrams and sync edges as adjacency-friendly data.
+
+    Examples:
+        ```python
+        graph = EdgeDraw(names=["A", "B", "C", "D"])
+        graph
+        ```
+    """
 
     _esm = Path(__file__).parent / "static" / "edgedraw.js"
     _css = Path(__file__).parent / "static" / "edgedraw.css"

--- a/wigglystuff/gamepad.py
+++ b/wigglystuff/gamepad.py
@@ -9,6 +9,12 @@ class GamepadWidget(anywidget.AnyWidget):
 
     This widget does not require any initialization arguments; all state is
     mirrored through traitlets such as ``axes`` and ``current_button_press``.
+
+    Examples:
+        ```python
+        gamepad = GamepadWidget()
+        gamepad
+        ```
     """
 
     _esm = Path(__file__).parent / "static" / "gamepad-widget.js"

--- a/wigglystuff/keystroke.py
+++ b/wigglystuff/keystroke.py
@@ -9,6 +9,12 @@ class KeystrokeWidget(anywidget.AnyWidget):
 
     No initialization arguments are required; the widget simply records
     keystrokes into the ``last_key`` trait.
+
+    Examples:
+        ```python
+        keystroke = KeystrokeWidget()
+        keystroke
+        ```
     """
 
     _esm = Path(__file__).parent / "static" / "keystroke-widget.js"

--- a/wigglystuff/matrix.py
+++ b/wigglystuff/matrix.py
@@ -7,7 +7,14 @@ import traitlets
 
 
 class Matrix(anywidget.AnyWidget):
-    """Spreadsheet-like numeric editor with bounds, naming, and symmetry helpers."""
+    """Spreadsheet-like numeric editor with bounds, naming, and symmetry helpers.
+
+    Examples:
+        ```python
+        matrix = Matrix(rows=3, cols=3, min_value=0, max_value=10)
+        matrix
+        ```
+    """
 
     _esm = Path(__file__).parent / "static" / "matrix.js"
     _css = Path(__file__).parent / "static" / "matrix.css"

--- a/wigglystuff/paint.py
+++ b/wigglystuff/paint.py
@@ -79,7 +79,14 @@ def input_to_pil(input_data: Union[str, Path, "Image.Image", bytes, None]):
 
 
 class Paint(anywidget.AnyWidget):
-    """Notebook-friendly paint widget with MS Paint style tools and PIL helpers."""
+    """Notebook-friendly paint widget with MS Paint style tools and PIL helpers.
+
+    Examples:
+        ```python
+        paint = Paint(width=400, height=300)
+        paint
+        ```
+    """
 
     _esm = Path(__file__).parent / "static" / "paint.js"
     _css = Path(__file__).parent / "static" / "paint.css"

--- a/wigglystuff/slider2d.py
+++ b/wigglystuff/slider2d.py
@@ -10,6 +10,12 @@ class Slider2D(anywidget.AnyWidget):
 
     Emits synchronized ``x``/``y`` floats that stay within configurable bounds
     while rendering to a pixel canvas sized via ``width``/``height``.
+
+    Examples:
+        ```python
+        slider = Slider2D(x=0.5, y=0.5, x_bounds=(0.0, 1.0), y_bounds=(0.0, 1.0))
+        slider
+        ```
     """
 
     _esm = Path(__file__).parent / "static" / "2dslider.js"

--- a/wigglystuff/sortable_list.py
+++ b/wigglystuff/sortable_list.py
@@ -6,7 +6,14 @@ import traitlets
 
 
 class SortableList(anywidget.AnyWidget):
-    """Drag-and-drop list widget with optional add/remove/edit affordances."""
+    """Drag-and-drop list widget with optional add/remove/edit affordances.
+
+    Examples:
+        ```python
+        sortable = SortableList(value=["apple", "banana", "cherry"], removable=True)
+        sortable
+        ```
+    """
 
     _esm = Path(__file__).parent / "static" / "sortable-list.js"
     _css = Path(__file__).parent / "static" / "sortable-list.css"

--- a/wigglystuff/talk.py
+++ b/wigglystuff/talk.py
@@ -9,6 +9,12 @@ class WebkitSpeechToTextWidget(anywidget.AnyWidget):
 
     The widget exposes the ``transcript`` text along with the ``listening`` and
     ``trigger_listen`` booleans; it does not require initialization arguments.
+
+    Examples:
+        ```python
+        speech = WebkitSpeechToTextWidget()
+        speech
+        ```
     """
 
     transcript = traitlets.Unicode("").tag(sync=True)

--- a/wigglystuff/tangle.py
+++ b/wigglystuff/tangle.py
@@ -6,7 +6,14 @@ import traitlets
 
 
 class TangleSlider(anywidget.AnyWidget):
-    """Inline slider inspired by Bret Victor's Tangle UI."""
+    """Inline slider inspired by Bret Victor's Tangle UI.
+
+    Examples:
+        ```python
+        slider = TangleSlider(amount=50, min_value=0, max_value=100)
+        slider
+        ```
+    """
 
     _esm = Path(__file__).parent / "static" / "tangle-slider.js"
     amount = traitlets.Float(0.0).tag(sync=True)
@@ -59,7 +66,14 @@ class TangleSlider(anywidget.AnyWidget):
 
 
 class TangleChoice(anywidget.AnyWidget):
-    """Inline choice widget that cycles through labeled options."""
+    """Inline choice widget that cycles through labeled options.
+
+    Examples:
+        ```python
+        choice = TangleChoice(choices=["small", "medium", "large"])
+        choice
+        ```
+    """
 
     _esm = Path(__file__).parent / "static" / "tangle-choice.js"
     choice = traitlets.Unicode("").tag(sync=True)
@@ -78,7 +92,14 @@ class TangleChoice(anywidget.AnyWidget):
 
 
 class TangleSelect(anywidget.AnyWidget):
-    """Dropdown-based take on the Tangle choice pattern."""
+    """Dropdown-based take on the Tangle choice pattern.
+
+    Examples:
+        ```python
+        select = TangleSelect(choices=["red", "green", "blue"])
+        select
+        ```
+    """
 
     _esm = Path(__file__).parent / "static" / "tangle-select.js"
     choice = traitlets.Unicode("").tag(sync=True)


### PR DESCRIPTION
## Summary
- Add copy-paste examples to all widget API docstrings in `Examples:` format
- Fix CellTour docstring indentation with proper markdown code fences
- Remove DriverTour from nav (internal implementation detail)
- Enforce light mode only in mkdocs palette configuration

All widgets now have minimal but complete examples users can copy directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)