### PR TITLE
Fix webcam stream race and set package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "windhoek",
+  "name": "wigglystuff",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "wigglystuff",
   "scripts": {
     "dev-copy-btn": "./node_modules/.bin/esbuild js/copybutton/widget.tsx --bundle --outfile=wigglystuff/static/copybutton.js --format=esm --watch --minify"
   },


### PR DESCRIPTION
Fixes webcam preview races when switching facing mode by ignoring stale getUserMedia responses. Also sets the npm package name to keep the lockfile stable.