### PR TITLE
Document synced traitlets for widgets

### DIFF
--- a/mkdocs/reference/cell-tour.md
+++ b/mkdocs/reference/cell-tour.md
@@ -1,3 +1,13 @@
 # CellTour API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `steps` | `list[dict]` | DriverTour-style steps (CellTour inputs are normalized). |
+| `auto_start` | `bool` | Start tour automatically on render. |
+| `show_progress` | `bool` | Show progress indicator when true. |
+| `active` | `bool` | Whether the tour is currently running. |
+| `current_step` | `int` | Index of the active step. |
+
 ::: wigglystuff.cell_tour.CellTour

--- a/mkdocs/reference/color-picker.md
+++ b/mkdocs/reference/color-picker.md
@@ -1,3 +1,9 @@
 # ColorPicker API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `color` | `str` | Hex color string (e.g., `#ff00aa`). |
+
 ::: wigglystuff.color_picker.ColorPicker

--- a/mkdocs/reference/copy-to-clipboard.md
+++ b/mkdocs/reference/copy-to-clipboard.md
@@ -1,3 +1,9 @@
 # CopyToClipboard API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `text_to_copy` | `str` | Payload copied when the button is pressed. |
+
 ::: wigglystuff.copy_to_clipboard.CopyToClipboard

--- a/mkdocs/reference/edge-draw.md
+++ b/mkdocs/reference/edge-draw.md
@@ -1,3 +1,13 @@
 # EdgeDraw API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `names` | `list[str]` | Ordered node labels. |
+| `links` | `list[dict]` | Link dicts with `source` and `target` keys. |
+| `directed` | `bool` | Draw directed edges when true. |
+| `width` | `int` | Canvas width in pixels. |
+| `height` | `int` | Canvas height in pixels. |
+
 ::: wigglystuff.edge_draw.EdgeDraw

--- a/mkdocs/reference/gamepad.md
+++ b/mkdocs/reference/gamepad.md
@@ -1,3 +1,17 @@
 # GamepadWidget API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `current_button_press` | `int` | Index of the most recently pressed button. |
+| `current_timestamp` | `float` | Timestamp (ms since epoch) of the latest press. |
+| `previous_timestamp` | `float` | Timestamp of the previous press. |
+| `axes` | `list[float]` | Analog stick positions (4 values). |
+| `dpad_up` | `bool` | D-pad up state. |
+| `dpad_down` | `bool` | D-pad down state. |
+| `dpad_left` | `bool` | D-pad left state. |
+| `dpad_right` | `bool` | D-pad right state. |
+| `button_id` | `int` | Reserved for custom mappings (not set by the default UI). |
+
 ::: wigglystuff.gamepad.GamepadWidget

--- a/mkdocs/reference/keystroke.md
+++ b/mkdocs/reference/keystroke.md
@@ -1,3 +1,18 @@
 # KeystrokeWidget API
 
+## Synced traitlets
+
+`last_key` is a dictionary synced from the browser after each keypress. When no
+keypress has been captured yet, it is an empty dict.
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `key` | `str` | Display value for the key (e.g., `a`, `Enter`). |
+| `code` | `str` | Physical key code (e.g., `KeyA`, `Enter`). |
+| `ctrlKey` | `bool` | `True` when Control is held. |
+| `shiftKey` | `bool` | `True` when Shift is held. |
+| `altKey` | `bool` | `True` when Alt/Option is held. |
+| `metaKey` | `bool` | `True` when Command/Meta is held. |
+| `timestamp` | `int` | Milliseconds since epoch at capture time. |
+
 ::: wigglystuff.keystroke.KeystrokeWidget

--- a/mkdocs/reference/matrix.md
+++ b/mkdocs/reference/matrix.md
@@ -1,3 +1,20 @@
 # Matrix API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `matrix` | `list[list[float]]` | Cell values. |
+| `rows` | `int` | Row count. |
+| `cols` | `int` | Column count. |
+| `min_value` | `float` | Minimum allowed value. |
+| `max_value` | `float` | Maximum allowed value. |
+| `mirror` | `bool` | Mirror edits across the diagonal when enabled. |
+| `step` | `float` | Step size for edits. |
+| `digits` | `int` | Decimal precision for display. |
+| `row_names` | `list[str]` | Optional row labels. |
+| `col_names` | `list[str]` | Optional column labels. |
+| `static` | `bool` | Disable editing when true. |
+| `flexible_cols` | `bool` | Allow column count changes interactively. |
+
 ::: wigglystuff.matrix.Matrix

--- a/mkdocs/reference/paint.md
+++ b/mkdocs/reference/paint.md
@@ -1,3 +1,12 @@
 # Paint API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `base64` | `str` | PNG data URL or raw base64 payload. |
+| `width` | `int` | Canvas width in pixels. |
+| `height` | `int` | Canvas height in pixels. |
+| `store_background` | `bool` | Persist strokes when background changes. |
+
 ::: wigglystuff.paint.Paint

--- a/mkdocs/reference/slider2d.md
+++ b/mkdocs/reference/slider2d.md
@@ -1,3 +1,14 @@
 # Slider2D API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `x` | `float` | Current x position. |
+| `y` | `float` | Current y position. |
+| `x_bounds` | `tuple[float, float]` | Min/max x bounds. |
+| `y_bounds` | `tuple[float, float]` | Min/max y bounds. |
+| `width` | `int` | Canvas width in pixels. |
+| `height` | `int` | Canvas height in pixels. |
+
 ::: wigglystuff.slider2d.Slider2D

--- a/mkdocs/reference/sortable-list.md
+++ b/mkdocs/reference/sortable-list.md
@@ -1,3 +1,13 @@
 # SortableList API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `value` | `list[str]` | Ordered list items. |
+| `addable` | `bool` | Allow inserting new items. |
+| `removable` | `bool` | Allow deleting items. |
+| `editable` | `bool` | Allow inline edits. |
+| `label` | `str` | Optional heading above the list. |
+
 ::: wigglystuff.sortable_list.SortableList

--- a/mkdocs/reference/talk.md
+++ b/mkdocs/reference/talk.md
@@ -1,3 +1,11 @@
 # WebkitSpeechToTextWidget API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `transcript` | `str` | Latest transcript from the browser. |
+| `listening` | `bool` | Whether speech recognition is active. |
+| `trigger_listen` | `bool` | Toggle listening when set to true (auto-resets). |
+
 ::: wigglystuff.talk.WebkitSpeechToTextWidget

--- a/mkdocs/reference/tangle.md
+++ b/mkdocs/reference/tangle.md
@@ -1,7 +1,40 @@
 # Tangle Widgets API
 
+## TangleSlider
+
+### Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `amount` | `float` | Current value. |
+| `min_value` | `float` | Lower bound. |
+| `max_value` | `float` | Upper bound. |
+| `step` | `float` | Step size. |
+| `pixels_per_step` | `int` | Drag distance per step. |
+| `prefix` | `str` | Text before the value. |
+| `suffix` | `str` | Text after the value. |
+| `digits` | `int` | Decimal precision for display. |
+
 ::: wigglystuff.tangle.TangleSlider
 
+## TangleChoice
+
+### Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `choice` | `str` | Current selection. |
+| `choices` | `list[str]` | Available options. |
+
 ::: wigglystuff.tangle.TangleChoice
+
+## TangleSelect
+
+### Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `choice` | `str` | Current selection. |
+| `choices` | `list[str]` | Available options. |
 
 ::: wigglystuff.tangle.TangleSelect

--- a/mkdocs/reference/webcam-capture.md
+++ b/mkdocs/reference/webcam-capture.md
@@ -1,3 +1,14 @@
 # WebcamCapture API
 
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `image_base64` | `str` | PNG data URL for the latest frame. |
+| `capturing` | `bool` | Enable auto-capture mode. |
+| `interval_ms` | `int` | Auto-capture interval in milliseconds. |
+| `facing_mode` | `str` | Camera facing mode ("user" or "environment"). |
+| `ready` | `bool` | True when the preview stream is ready. |
+| `error` | `str` | Error message when webcam access fails. |
+
 ::: wigglystuff.webcam_capture.WebcamCapture

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "windhoek",
+  "name": "wigglystuff",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "wigglystuff",
       "dependencies": {
         "@anywidget/react": "^0.1.0",
         "@radix-ui/react-icons": "^1.3.2",

--- a/wigglystuff/keystroke.py
+++ b/wigglystuff/keystroke.py
@@ -10,6 +10,10 @@ class KeystrokeWidget(anywidget.AnyWidget):
     No initialization arguments are required; the widget simply records
     keystrokes into the ``last_key`` trait.
 
+    The ``last_key`` payload mirrors browser ``KeyboardEvent`` data with:
+    ``key``, ``code``, modifier booleans (``ctrlKey``, ``shiftKey``,
+    ``altKey``, ``metaKey``), and a ``timestamp`` in milliseconds since epoch.
+
     Examples:
         ```python
         keystroke = KeystrokeWidget()


### PR DESCRIPTION
Add synced traitlet tables to each widget reference page so outputs are explicit. Includes a keystroke payload note and updates the lockfile package name.