### PR TITLE
Add markdown sources to docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: js docs test docs-demos docs-serve docs-build marimo-notebook
+.PHONY: js docs test docs-demos docs-serve docs-build docs-llm docs-gh marimo-notebook
 
 install:
 	# install the build tool for JS written in Golang
@@ -45,6 +45,7 @@ clean:
 
 docs: docs-demos
 	mkdocs build -f mkdocs.yml
+	uv run python scripts/copy_docs_md.py
 
 docs-demos:
 	uv run python scripts/export_marimo_demos.py --force
@@ -54,9 +55,15 @@ docs-serve:
 
 docs-build: docs-demos
 	uv run mkdocs build -f mkdocs.yml
+	uv run python scripts/copy_docs_md.py
+
+docs-llm:
+	uv run python scripts/copy_docs_md.py
 
 docs-gh: docs-demos
-	uv run mkdocs gh-deploy -f mkdocs.yml
+	uv run mkdocs build -f mkdocs.yml
+	uv run python scripts/copy_docs_md.py
+	uv run mkdocs gh-deploy -f mkdocs.yml --dirty
 
 marimo-notebook:
 	uv run marimo -y export html-wasm notebook.py --output docs/index.html --mode edit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "windhoek",
+  "name": "wigglystuff",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "wigglystuff",
       "dependencies": {
         "@anywidget/react": "^0.1.0",
         "@radix-ui/react-icons": "^1.3.2",

--- a/scripts/copy_docs_md.py
+++ b/scripts/copy_docs_md.py
@@ -1,0 +1,66 @@
+"""Copy markdown sources into the built site for LLM consumption."""
+
+from __future__ import annotations
+
+import fnmatch
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MKDOCS_YML = ROOT / "mkdocs.yml"
+
+
+def _parse_top_level_value(lines: list[str], key: str) -> str | None:
+    prefix = f"{key}:"
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        value = line[len(prefix) :].strip()
+        if value:
+            return value.strip("'\"")
+        # handle a simple YAML list
+        values: list[str] = []
+        for item in lines[index + 1 :]:
+            if item and not item.startswith(" "):
+                break
+            stripped = item.strip()
+            if stripped.startswith("-"):
+                values.append(stripped[1:].strip().strip("'\""))
+        if values:
+            return ",".join(values)
+    return None
+
+
+def _load_config() -> tuple[Path, Path, list[str]]:
+    lines = MKDOCS_YML.read_text(encoding="utf-8").splitlines()
+    docs_dir = _parse_top_level_value(lines, "docs_dir") or "mkdocs"
+    site_dir = _parse_top_level_value(lines, "site_dir") or "site"
+    exclude_raw = _parse_top_level_value(lines, "exclude_docs") or ""
+    excludes = [value.strip() for value in exclude_raw.split(",") if value.strip()]
+    return ROOT / docs_dir, ROOT / site_dir, excludes
+
+
+def _is_excluded(relative_posix: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(relative_posix, pattern) for pattern in patterns)
+
+
+def main() -> None:
+    docs_dir, site_dir, excludes = _load_config()
+    target_dir = site_dir / "llm"
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    for source in sorted(docs_dir.rglob("*.md")):
+        relative = source.relative_to(docs_dir).as_posix()
+        if _is_excluded(relative, excludes):
+            continue
+        destination = target_dir / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    print(f"[docs] copied markdown to {target_dir.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a docs build step that copies the markdown sources into site/llm for LLM ingestion. Updates docs targets to run the copy step and deploy with --dirty.