### PR TITLE
Fix docs links and markdown export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docs-demos:
 	uv run python scripts/export_marimo_demos.py --force
 
 docs-serve:
-	uv run mkdocs serve -f mkdocs.yml
+	uv run python -m http.server --directory site
 
 docs-build: docs-demos
 	uv run mkdocs build -f mkdocs.yml
@@ -60,9 +60,7 @@ docs-build: docs-demos
 docs-llm:
 	uv run python scripts/copy_docs_md.py
 
-docs-gh: docs-demos
-	uv run mkdocs build -f mkdocs.yml
-	uv run python scripts/copy_docs_md.py
+docs-gh: docs-build
 	uv run mkdocs gh-deploy -f mkdocs.yml --dirty
 
 marimo-notebook:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ pypi: clean
 js-edgedraw:
 	./esbuild --watch=forever --bundle --format=esm --outfile=wigglystuff/static/edgedraw.js js/edgedraw.js
 
-
 js-gamepad:
 	./esbuild --bundle --format=esm --outfile=wigglystuff/static/gamepad-widget.js js/gamepad/widget.js
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - CopyToClipboard: reference/copy-to-clipboard.md
       - Tangle Widgets: reference/tangle.md
       - GamepadWidget: reference/gamepad.md
+      - WebcamCapture: reference/webcam-capture.md
       - CellTour: reference/cell-tour.md
 plugins:
   - search

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -29,62 +29,62 @@ hide:
 <div class="gallery-item">
 <div class="gallery-title">Slider2D</div>
 <a href="examples/slider2d/index.html" class="gallery-img"><img src="assets/gallery/slider2d.png" alt="Slider2D widget"></a>
-<div class="gallery-links"><a href="examples/slider2d/index.html">Demo</a><a href="reference/slider2d.md">API</a></div>
+<div class="gallery-links"><a href="examples/slider2d/index.html">Demo</a><a href="reference/slider2d/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">Matrix</div>
 <a href="examples/matrix/index.html" class="gallery-img"><img src="assets/gallery/matrix.png" alt="Matrix widget"></a>
-<div class="gallery-links"><a href="examples/matrix/index.html">Demo</a><a href="reference/matrix.md">API</a></div>
+<div class="gallery-links"><a href="examples/matrix/index.html">Demo</a><a href="reference/matrix/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">Paint</div>
 <a href="examples/paint/index.html" class="gallery-img"><img src="assets/gallery/paint.png" alt="Paint widget"></a>
-<div class="gallery-links"><a href="examples/paint/index.html">Demo</a><a href="reference/paint.md">API</a></div>
+<div class="gallery-links"><a href="examples/paint/index.html">Demo</a><a href="reference/paint/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">EdgeDraw</div>
 <a href="examples/edgedraw/index.html" class="gallery-img"><img src="assets/gallery/edgedraw.png" alt="EdgeDraw widget"></a>
-<div class="gallery-links"><a href="examples/edgedraw/index.html">Demo</a><a href="reference/edge-draw.md">API</a></div>
+<div class="gallery-links"><a href="examples/edgedraw/index.html">Demo</a><a href="reference/edge-draw/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">SortableList</div>
 <a href="examples/sortlist/index.html" class="gallery-img"><img src="assets/gallery/sortablelist.png" alt="SortableList widget"></a>
-<div class="gallery-links"><a href="examples/sortlist/index.html">Demo</a><a href="reference/sortable-list.md">API</a></div>
+<div class="gallery-links"><a href="examples/sortlist/index.html">Demo</a><a href="reference/sortable-list/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">ColorPicker</div>
 <a href="examples/colorpicker/index.html" class="gallery-img"><img src="assets/gallery/colorpicker.png" alt="ColorPicker widget"></a>
-<div class="gallery-links"><a href="examples/colorpicker/index.html">Demo</a><a href="reference/color-picker.md">API</a></div>
+<div class="gallery-links"><a href="examples/colorpicker/index.html">Demo</a><a href="reference/color-picker/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">GamepadWidget</div>
 <a href="examples/gamepad/index.html" class="gallery-img"><img src="assets/gallery/gamepad.png" alt="GamepadWidget"></a>
-<div class="gallery-links"><a href="examples/gamepad/index.html">Demo</a><a href="reference/gamepad.md">API</a></div>
+<div class="gallery-links"><a href="examples/gamepad/index.html">Demo</a><a href="reference/gamepad/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">KeystrokeWidget</div>
 <a href="examples/keystroke/index.html" class="gallery-img"><img src="assets/gallery/keystroke.png" alt="KeystrokeWidget"></a>
-<div class="gallery-links"><a href="examples/keystroke/index.html">Demo</a><a href="reference/keystroke.md">API</a></div>
+<div class="gallery-links"><a href="examples/keystroke/index.html">Demo</a><a href="reference/keystroke/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">SpeechToText</div>
 <a href="examples/talk/index.html" class="gallery-img"><img src="assets/gallery/speechtotext.png" alt="WebkitSpeechToText widget"></a>
-<div class="gallery-links"><a href="examples/talk/index.html">Demo</a><a href="reference/talk.md">API</a></div>
+<div class="gallery-links"><a href="examples/talk/index.html">Demo</a><a href="reference/talk/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">CopyToClipboard</div>
 <a href="examples/copytoclipboard/index.html" class="gallery-img"><img src="assets/gallery/copytoclipboard.png" alt="CopyToClipboard widget"></a>
-<div class="gallery-links"><a href="examples/copytoclipboard/index.html">Demo</a><a href="reference/copy-to-clipboard.md">API</a></div>
+<div class="gallery-links"><a href="examples/copytoclipboard/index.html">Demo</a><a href="reference/copy-to-clipboard/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">CellTour</div>
 <a href="examples/celltour/index.html" class="gallery-img"><img src="assets/gallery/celltour.png" alt="CellTour widget"></a>
-<div class="gallery-links"><a href="examples/celltour/index.html">Demo</a><a href="reference/cell-tour.md">API</a></div>
+<div class="gallery-links"><a href="examples/celltour/index.html">Demo</a><a href="reference/cell-tour/">API</a></div>
 </div>
 <div class="gallery-item">
 <div class="gallery-title">WebcamCapture</div>
 <a href="examples/webcam-capture/index.html" class="gallery-img"><img src="assets/gallery/webcam-capture.png" alt="WebcamCapture widget"></a>
-<div class="gallery-links"><a href="examples/webcam-capture/index.html">Demo</a><a href="reference/webcam-capture.md">API</a></div>
+<div class="gallery-links"><a href="examples/webcam-capture/index.html">Demo</a><a href="reference/webcam-capture/">API</a></div>
 </div>
 </div>
 

--- a/mkdocs/reference/cell-tour.md
+++ b/mkdocs/reference/cell-tour.md
@@ -1,5 +1,7 @@
 # CellTour API
 
+::: wigglystuff.cell_tour.CellTour
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -10,4 +12,3 @@
 | `active` | `bool` | Whether the tour is currently running. |
 | `current_step` | `int` | Index of the active step. |
 
-::: wigglystuff.cell_tour.CellTour

--- a/mkdocs/reference/color-picker.md
+++ b/mkdocs/reference/color-picker.md
@@ -1,9 +1,10 @@
 # ColorPicker API
 
+::: wigglystuff.color_picker.ColorPicker
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
 | --- | --- | --- |
 | `color` | `str` | Hex color string (e.g., `#ff00aa`). |
 
-::: wigglystuff.color_picker.ColorPicker

--- a/mkdocs/reference/copy-to-clipboard.md
+++ b/mkdocs/reference/copy-to-clipboard.md
@@ -1,9 +1,10 @@
 # CopyToClipboard API
 
+::: wigglystuff.copy_to_clipboard.CopyToClipboard
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
 | --- | --- | --- |
 | `text_to_copy` | `str` | Payload copied when the button is pressed. |
 
-::: wigglystuff.copy_to_clipboard.CopyToClipboard

--- a/mkdocs/reference/edge-draw.md
+++ b/mkdocs/reference/edge-draw.md
@@ -1,5 +1,7 @@
 # EdgeDraw API
 
+::: wigglystuff.edge_draw.EdgeDraw
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -10,4 +12,3 @@
 | `width` | `int` | Canvas width in pixels. |
 | `height` | `int` | Canvas height in pixels. |
 
-::: wigglystuff.edge_draw.EdgeDraw

--- a/mkdocs/reference/gamepad.md
+++ b/mkdocs/reference/gamepad.md
@@ -1,5 +1,7 @@
 # GamepadWidget API
 
+::: wigglystuff.gamepad.GamepadWidget
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -14,4 +16,3 @@
 | `dpad_right` | `bool` | D-pad right state. |
 | `button_id` | `int` | Reserved for custom mappings (not set by the default UI). |
 
-::: wigglystuff.gamepad.GamepadWidget

--- a/mkdocs/reference/keystroke.md
+++ b/mkdocs/reference/keystroke.md
@@ -1,5 +1,7 @@
 # KeystrokeWidget API
 
+::: wigglystuff.keystroke.KeystrokeWidget
+
 ## Synced traitlets
 
 `last_key` is a dictionary synced from the browser after each keypress. When no
@@ -15,4 +17,3 @@ keypress has been captured yet, it is an empty dict.
 | `metaKey` | `bool` | `True` when Command/Meta is held. |
 | `timestamp` | `int` | Milliseconds since epoch at capture time. |
 
-::: wigglystuff.keystroke.KeystrokeWidget

--- a/mkdocs/reference/matrix.md
+++ b/mkdocs/reference/matrix.md
@@ -1,5 +1,7 @@
 # Matrix API
 
+::: wigglystuff.matrix.Matrix
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -17,4 +19,3 @@
 | `static` | `bool` | Disable editing when true. |
 | `flexible_cols` | `bool` | Allow column count changes interactively. |
 
-::: wigglystuff.matrix.Matrix

--- a/mkdocs/reference/paint.md
+++ b/mkdocs/reference/paint.md
@@ -1,5 +1,7 @@
 # Paint API
 
+::: wigglystuff.paint.Paint
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -9,4 +11,3 @@
 | `height` | `int` | Canvas height in pixels. |
 | `store_background` | `bool` | Persist strokes when background changes. |
 
-::: wigglystuff.paint.Paint

--- a/mkdocs/reference/slider2d.md
+++ b/mkdocs/reference/slider2d.md
@@ -1,5 +1,7 @@
 # Slider2D API
 
+::: wigglystuff.slider2d.Slider2D
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -11,4 +13,3 @@
 | `width` | `int` | Canvas width in pixels. |
 | `height` | `int` | Canvas height in pixels. |
 
-::: wigglystuff.slider2d.Slider2D

--- a/mkdocs/reference/sortable-list.md
+++ b/mkdocs/reference/sortable-list.md
@@ -1,5 +1,7 @@
 # SortableList API
 
+::: wigglystuff.sortable_list.SortableList
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -10,4 +12,3 @@
 | `editable` | `bool` | Allow inline edits. |
 | `label` | `str` | Optional heading above the list. |
 
-::: wigglystuff.sortable_list.SortableList

--- a/mkdocs/reference/talk.md
+++ b/mkdocs/reference/talk.md
@@ -1,5 +1,7 @@
 # WebkitSpeechToTextWidget API
 
+::: wigglystuff.talk.WebkitSpeechToTextWidget
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -8,4 +10,3 @@
 | `listening` | `bool` | Whether speech recognition is active. |
 | `trigger_listen` | `bool` | Toggle listening when set to true (auto-resets). |
 
-::: wigglystuff.talk.WebkitSpeechToTextWidget

--- a/mkdocs/reference/tangle.md
+++ b/mkdocs/reference/tangle.md
@@ -2,6 +2,8 @@
 
 ## TangleSlider
 
+::: wigglystuff.tangle.TangleSlider
+
 ### Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -15,10 +17,11 @@
 | `suffix` | `str` | Text after the value. |
 | `digits` | `int` | Decimal precision for display. |
 
-::: wigglystuff.tangle.TangleSlider
 
 ## TangleChoice
 
+::: wigglystuff.tangle.TangleChoice
+
 ### Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -26,10 +29,11 @@
 | `choice` | `str` | Current selection. |
 | `choices` | `list[str]` | Available options. |
 
-::: wigglystuff.tangle.TangleChoice
 
 ## TangleSelect
 
+::: wigglystuff.tangle.TangleSelect
+
 ### Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -37,4 +41,3 @@
 | `choice` | `str` | Current selection. |
 | `choices` | `list[str]` | Available options. |
 
-::: wigglystuff.tangle.TangleSelect

--- a/mkdocs/reference/webcam-capture.md
+++ b/mkdocs/reference/webcam-capture.md
@@ -1,5 +1,7 @@
 # WebcamCapture API
 
+::: wigglystuff.webcam_capture.WebcamCapture
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |
@@ -11,4 +13,3 @@
 | `ready` | `bool` | True when the preview stream is ready. |
 | `error` | `str` | Error message when webcam access fails. |
 
-::: wigglystuff.webcam_capture.WebcamCapture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.5"
+version = "0.2.6"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/copy_docs_md.py
+++ b/scripts/copy_docs_md.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import fnmatch
+import re
 import shutil
 from pathlib import Path
+from html.parser import HTMLParser
 
 ROOT = Path(__file__).resolve().parents[1]
 MKDOCS_YML = ROOT / "mkdocs.yml"
@@ -44,22 +46,278 @@ def _is_excluded(relative_posix: str, patterns: list[str]) -> bool:
     return any(fnmatch.fnmatch(relative_posix, pattern) for pattern in patterns)
 
 
+def _html_path_for(relative: str, site_dir: Path) -> Path:
+    if relative == "index.md":
+        return site_dir / "index.html"
+    return site_dir / relative.removesuffix(".md") / "index.html"
+
+
+def _extract_article_html(html: str) -> str | None:
+    marker = '<article class="md-content__inner md-typeset">'
+    start = html.find(marker)
+    if start == -1:
+        return None
+    start += len(marker)
+    end = html.find("</article>", start)
+    if end == -1:
+        return None
+    return html[start:end]
+
+
+class _HtmlToMarkdown(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._lines: list[str] = []
+        self._line: list[str] = []
+        self._list_stack: list[dict[str, int | str]] = []
+        self._in_pre = False
+        self._pre_buffer: list[str] = []
+        self._pre_lang: str | None = None
+        self._in_code_inline = False
+        self._code_buffer: list[str] = []
+        self._code_target: str = "line"
+        self._skip_depth = 0
+        self._in_table = False
+        self._table_rows: list[list[str]] = []
+        self._current_row: list[str] = []
+        self._current_cell: list[str] = []
+        self._row_has_th = False
+        self._first_row_is_header = False
+        self._in_highlight_table = False
+
+    def get_markdown(self) -> str:
+        self._flush_line()
+        self._trim_trailing_blank_lines()
+        return "\n".join(self._lines).strip() + "\n"
+
+    def _trim_trailing_blank_lines(self) -> None:
+        while self._lines and not self._lines[-1].strip():
+            self._lines.pop()
+
+    def _flush_line(self) -> None:
+        if not self._line:
+            return
+        line = "".join(self._line).rstrip()
+        self._lines.append(line)
+        self._line = []
+
+    def _ensure_blank_line(self) -> None:
+        if self._line:
+            self._flush_line()
+        if not self._lines or self._lines[-1].strip():
+            self._lines.append("")
+
+    def _start_block(self) -> None:
+        self._ensure_blank_line()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if self._skip_depth:
+            self._skip_depth += 1
+            return
+        attr_map = {k: v or "" for k, v in attrs}
+        if tag == "a" and "headerlink" in attr_map.get("class", ""):
+            self._skip_depth = 1
+            return
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._flush_line()
+            self._ensure_blank_line()
+            level = int(tag[1])
+            self._line.append("#" * level + " ")
+        elif tag == "p":
+            self._start_block()
+        elif tag == "br":
+            self._flush_line()
+        elif tag == "ul":
+            self._start_block()
+            self._list_stack.append({"type": "ul", "count": 0})
+        elif tag == "ol":
+            self._start_block()
+            self._list_stack.append({"type": "ol", "count": 1})
+        elif tag == "li":
+            self._flush_line()
+            indent = "  " * max(len(self._list_stack) - 1, 0)
+            if self._list_stack and self._list_stack[-1]["type"] == "ol":
+                count = int(self._list_stack[-1]["count"])
+                self._list_stack[-1]["count"] = count + 1
+                bullet = f"{count}."
+            else:
+                bullet = "-"
+            self._line.append(f"{indent}{bullet} ")
+        elif tag == "pre":
+            self._start_block()
+            self._in_pre = True
+            self._pre_buffer = []
+            self._pre_lang = None
+        elif tag == "code" and self._in_pre:
+            class_name = attr_map.get("class", "")
+            match = re.search(r"language-([a-zA-Z0-9_+-]+)", class_name)
+            if match:
+                self._pre_lang = match.group(1)
+        elif tag == "code":
+            self._in_code_inline = True
+            self._code_buffer = []
+            self._code_target = "cell" if self._in_table else "line"
+        elif tag in {"strong", "b"}:
+            self._line.append("**")
+        elif tag in {"em", "i"}:
+            self._line.append("*")
+        elif tag == "table":
+            if "highlighttable" in attr_map.get("class", ""):
+                self._in_highlight_table = True
+                return
+            self._start_block()
+            self._in_table = True
+            self._table_rows = []
+            self._current_row = []
+            self._current_cell = []
+            self._row_has_th = False
+            self._first_row_is_header = False
+        elif tag == "td" and self._in_highlight_table and "linenos" in attr_map.get("class", ""):
+            self._skip_depth = 1
+        elif tag == "tr" and self._in_table:
+            self._current_row = []
+            self._row_has_th = False
+        elif tag in {"th", "td"} and self._in_table:
+            self._current_cell = []
+            if tag == "th":
+                self._row_has_th = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._flush_line()
+            self._ensure_blank_line()
+        elif tag == "p":
+            self._flush_line()
+            self._ensure_blank_line()
+        elif tag in {"ul", "ol"}:
+            if self._list_stack:
+                self._list_stack.pop()
+            self._flush_line()
+            self._ensure_blank_line()
+        elif tag == "li":
+            self._flush_line()
+        elif tag == "pre":
+            self._in_pre = False
+            self._flush_pre()
+        elif tag == "code" and self._in_code_inline:
+            code_text = "".join(self._code_buffer).strip()
+            if code_text:
+                wrapped = f"`{code_text}`"
+                if self._code_target == "cell":
+                    self._current_cell.append(wrapped)
+                else:
+                    self._line.append(wrapped)
+            self._in_code_inline = False
+        elif tag in {"strong", "b"}:
+            self._line.append("**")
+        elif tag in {"em", "i"}:
+            self._line.append("*")
+        elif tag in {"th", "td"} and self._in_table:
+            cell_text = "".join(self._current_cell).strip()
+            self._current_row.append(cell_text)
+            self._current_cell = []
+        elif tag == "tr" and self._in_table:
+            if self._current_row:
+                if not self._table_rows:
+                    self._first_row_is_header = self._row_has_th
+                self._table_rows.append(self._current_row)
+            self._current_row = []
+        elif tag == "table":
+            if self._in_highlight_table:
+                self._in_highlight_table = False
+                return
+            self._emit_table()
+            self._in_table = False
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        if self._in_pre:
+            self._pre_buffer.append(data)
+            return
+        if self._in_code_inline:
+            self._code_buffer.append(data)
+            return
+        text = data
+        text = re.sub(r"\s+", " ", text)
+        if not text:
+            return
+        if self._in_table and self._current_cell is not None:
+            self._current_cell.append(text)
+            return
+        if self._line and self._line[-1].endswith(" "):
+            text = text.lstrip()
+        self._line.append(text)
+
+    def _flush_pre(self) -> None:
+        pre_text = "".join(self._pre_buffer)
+        pre_text = pre_text.rstrip("\n")
+        fence = f"```{self._pre_lang or ''}".rstrip()
+        self._lines.append(fence)
+        if pre_text:
+            self._lines.extend(pre_text.splitlines())
+        self._lines.append("```")
+        self._lines.append("")
+        self._pre_buffer = []
+        self._pre_lang = None
+
+    def _emit_table(self) -> None:
+        if not self._table_rows:
+            return
+        column_count = max(len(row) for row in self._table_rows)
+        rows = [row + [""] * (column_count - len(row)) for row in self._table_rows]
+        if self._first_row_is_header:
+            header = rows[0]
+            body = rows[1:]
+        else:
+            header = [""] * column_count
+            body = rows
+        header_line = "| " + " | ".join(self._escape_cell(cell) for cell in header) + " |"
+        separator = "| " + " | ".join("---" for _ in header) + " |"
+        self._lines.append(header_line)
+        self._lines.append(separator)
+        for row in body:
+            row_line = "| " + " | ".join(self._escape_cell(cell) for cell in row) + " |"
+            self._lines.append(row_line)
+        self._lines.append("")
+
+    @staticmethod
+    def _escape_cell(value: str) -> str:
+        return value.replace("|", r"\|").strip()
+
+
+def _html_to_markdown(html: str) -> str:
+    parser = _HtmlToMarkdown()
+    parser.feed(html)
+    return parser.get_markdown()
+
+
 def main() -> None:
     docs_dir, site_dir, excludes = _load_config()
-    target_dir = site_dir / "llm"
-    if target_dir.exists():
-        shutil.rmtree(target_dir)
-    target_dir.mkdir(parents=True, exist_ok=True)
+    legacy_dir = site_dir / "llm"
+    if legacy_dir.exists():
+        shutil.rmtree(legacy_dir)
 
     for source in sorted(docs_dir.rglob("*.md")):
         relative = source.relative_to(docs_dir).as_posix()
         if _is_excluded(relative, excludes):
             continue
-        destination = target_dir / relative
+        destination = site_dir / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
+        html_path = _html_path_for(relative, site_dir)
+        if html_path.exists():
+            html = html_path.read_text(encoding="utf-8")
+            article_html = _extract_article_html(html)
+            if article_html:
+                markdown = _html_to_markdown(article_html)
+                destination.write_text(markdown, encoding="utf-8")
+                continue
         destination.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
 
-    print(f"[docs] copied markdown to {target_dir.relative_to(ROOT)}")
+    print(f"[docs] copied markdown to {site_dir.relative_to(ROOT)}")
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
Fixes gallery API links to point at human-friendly reference URLs.\nMoves reference markdown to the built site and renders mkdocstrings output into .md files.\nAdds the WebcamCapture reference page to nav and reorders synced traitlets to the bottom.