### PR TITLE
Formula widget interactive update

### DIFF
--- a/wigglystuff/__init__.py
+++ b/wigglystuff/__init__.py
@@ -5,6 +5,7 @@ from .color_picker import ColorPicker
 from .copy_to_clipboard import CopyToClipboard
 from .driver_tour import DriverTour
 from .edge_draw import EdgeDraw
+from .formula import Formula
 from .gamepad import GamepadWidget
 from .keystroke import KeystrokeWidget
 from .matrix import Matrix
@@ -21,6 +22,7 @@ __all__ = [
     "CopyToClipboard",
     "DriverTour",
     "EdgeDraw",
+    "Formula",
     "GamepadWidget",
     "KeystrokeWidget",
     "Matrix",

--- a/wigglystuff/formula.py
+++ b/wigglystuff/formula.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import anywidget
+import traitlets
+
+
+class Formula(anywidget.AnyWidget):
+    """Interactive LaTeX formula widget with draggable numbers.
+
+    Examples:
+        ```python
+        formula = Formula(
+            formula=r"$x = {a} + {b}$",
+            values={"a": 5, "b": 3},
+            min_values={"a": 0, "b": 0},
+            max_values={"a": 10, "b": 10}
+        )
+        formula
+        ```
+    """
+
+    _esm = Path(__file__).parent / "static" / "formula.js"
+    _css = Path(__file__).parent / "static" / "formula.css"
+    formula = traitlets.Unicode("").tag(sync=True)
+    values = traitlets.Dict({}).tag(sync=True)
+    min_values = traitlets.Dict({}).tag(sync=True)
+    max_values = traitlets.Dict({}).tag(sync=True)
+    step_sizes = traitlets.Dict({}).tag(sync=True)
+    digits = traitlets.Dict({}).tag(sync=True)
+    pixels_per_step = traitlets.Int(2).tag(sync=True)
+
+    def __init__(
+        self,
+        formula: str,
+        values: Dict[str, float],
+        min_values: Optional[Dict[str, float]] = None,
+        max_values: Optional[Dict[str, float]] = None,
+        step_sizes: Optional[Dict[str, float]] = None,
+        digits: Optional[Dict[str, int]] = None,
+        pixels_per_step: int = 2,
+        **kwargs: Any,
+    ) -> None:
+        """Create a Formula widget with draggable numbers.
+
+        Args:
+            formula: LaTeX formula string with placeholders like {a}, {b}, etc.
+            values: Dictionary mapping placeholder names to initial values.
+            min_values: Optional dictionary mapping placeholder names to minimum values.
+                       Defaults to -100 for all placeholders.
+            max_values: Optional dictionary mapping placeholder names to maximum values.
+                       Defaults to 100 for all placeholders.
+            step_sizes: Optional dictionary mapping placeholder names to step sizes.
+                       Defaults to 1.0 for all placeholders.
+            digits: Optional dictionary mapping placeholder names to decimal precision.
+                   Defaults to 1 for all placeholders.
+            pixels_per_step: Number of pixels to drag per step increment.
+            **kwargs: Forwarded to ``anywidget.AnyWidget``.
+        """
+        # Extract placeholder names from formula
+        import re
+        placeholders = set(re.findall(r'\{(\w+)\}', formula))
+        
+        if not placeholders:
+            raise ValueError("Formula must contain at least one placeholder like {a}, {b}, etc.")
+        
+        if set(values.keys()) != placeholders:
+            raise ValueError(
+                f"Values keys {set(values.keys())} must match placeholders {placeholders} in formula"
+            )
+        
+        # Set defaults for optional parameters
+        if min_values is None:
+            min_values = {k: -100.0 for k in placeholders}
+        else:
+            min_values = {k: min_values.get(k, -100.0) for k in placeholders}
+        
+        if max_values is None:
+            max_values = {k: 100.0 for k in placeholders}
+        else:
+            max_values = {k: max_values.get(k, 100.0) for k in placeholders}
+        
+        if step_sizes is None:
+            step_sizes = {k: 1.0 for k in placeholders}
+        else:
+            step_sizes = {k: step_sizes.get(k, 1.0) for k in placeholders}
+        
+        if digits is None:
+            digits = {k: 1 for k in placeholders}
+        else:
+            digits = {k: digits.get(k, 1) for k in placeholders}
+        
+        # Validate values are within bounds
+        for k, v in values.items():
+            if v < min_values[k]:
+                raise ValueError(f"Value {v} for '{k}' is less than min_value {min_values[k]}")
+            if v > max_values[k]:
+                raise ValueError(f"Value {v} for '{k}' is greater than max_value {max_values[k]}")
+        
+        super().__init__(
+            formula=formula,
+            values=values,
+            min_values=min_values,
+            max_values=max_values,
+            step_sizes=step_sizes,
+            digits=digits,
+            pixels_per_step=pixels_per_step,
+            **kwargs,
+        )

--- a/wigglystuff/static/formula.css
+++ b/wigglystuff/static/formula.css
@@ -1,0 +1,36 @@
+.formula-container {
+    display: inline-block;
+    font-size: 18px;
+    line-height: 1.5;
+    padding: 10px;
+    user-select: none;
+}
+
+.formula-display {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.formula-draggable {
+    cursor: ew-resize;
+    color: #0066cc;
+    text-decoration: underline;
+    user-select: none;
+    display: inline-block;
+    position: relative;
+}
+
+.formula-draggable:hover {
+    opacity: 0.8;
+}
+
+.formula-draggable:active {
+    cursor: grabbing;
+}
+
+/* Dark mode support */
+.dark .formula-draggable,
+.dark-theme .formula-draggable,
+[data-theme="dark"] .formula-draggable {
+    color: #7dd3fc;
+}

--- a/wigglystuff/static/formula.js
+++ b/wigglystuff/static/formula.js
@@ -27,125 +27,97 @@ function render({model, el}) {
         el.innerHTML = '';
         el.classList.add("formula-container");
 
-        // Build LaTeX string with values substituted
-        // We'll use a unique class name via \class that we can find later
-        let latexString = formula;
-        const placeholderMap = {}; // Maps formatted value -> placeholder name
+        // Parse formula into parts: LaTeX text and placeholders
+        const placeholderRegex = /\{(\w+)\}/g;
+        const parts = [];
+        let lastIndex = 0;
+        let match;
         
-        Object.keys(values).forEach(placeholderName => {
-            const value = values[placeholderName];
-            const decimalPlaces = digits[placeholderName] || 1;
-            const formattedValue = value.toFixed(decimalPlaces);
-            
-            // Replace placeholder with formatted value wrapped in a special class
-            // Use \class to add a data attribute we can find
-            const placeholderRegex = new RegExp(`\\{${placeholderName}\\}`, 'g');
-            // Use \textcolor and \class for styling and identification
-            latexString = latexString.replace(
-                placeholderRegex,
-                `\\textcolor{blue}{\\underline{${formattedValue}}}`
-            );
-            
-            // Store mapping for later
-            placeholderMap[formattedValue] = placeholderName;
-        });
+        while ((match = placeholderRegex.exec(formula)) !== null) {
+            // Add LaTeX text before placeholder
+            if (match.index > lastIndex) {
+                parts.push({
+                    type: 'latex',
+                    content: formula.substring(lastIndex, match.index)
+                });
+            }
+            // Add placeholder
+            parts.push({
+                type: 'placeholder',
+                name: match[1]
+            });
+            lastIndex = match.index + match[0].length;
+        }
+        // Add remaining LaTeX text
+        if (lastIndex < formula.length) {
+            parts.push({
+                type: 'latex',
+                content: formula.substring(lastIndex)
+            });
+        }
 
         // Create container for formula
         const formulaDiv = document.createElement('div');
         formulaDiv.className = 'formula-display';
         formulaDiv.style.display = 'inline-block';
 
-        // Render the entire formula as one LaTeX expression
-        try {
-            katex.render(latexString, formulaDiv, {
-                throwOnError: false,
-                displayMode: false,
-            });
-        } catch (e) {
-            console.error('KaTeX rendering error:', e);
-            formulaDiv.textContent = latexString;
-        }
-
-        // Now find and make draggable the numbers we marked
-        // KaTeX renders \textcolor{blue}{\underline{value}} as spans with specific styling
-        // We need to find elements that contain our formatted values
-        makeValuesDraggable(formulaDiv, placeholderMap, values, digits);
+        // Render each part
+        parts.forEach(part => {
+            if (part.type === 'latex') {
+                if (part.content.trim()) {
+                    const latexSpan = document.createElement('span');
+                    latexSpan.style.display = 'inline-block';
+                    try {
+                        katex.render(part.content, latexSpan, {
+                            throwOnError: false,
+                            displayMode: false,
+                        });
+                    } catch (e) {
+                        console.error('KaTeX rendering error:', e);
+                        latexSpan.textContent = part.content;
+                    }
+                    formulaDiv.appendChild(latexSpan);
+                }
+            } else if (part.type === 'placeholder') {
+                // Create draggable value element
+                const placeholderName = part.name;
+                const value = values[placeholderName];
+                const decimalPlaces = digits[placeholderName] || 1;
+                const formattedValue = value.toFixed(decimalPlaces);
+                
+                // Render the number with KaTeX for consistent math font
+                const valueSpan = document.createElement('span');
+                valueSpan.className = 'formula-draggable';
+                valueSpan.dataset.placeholder = placeholderName;
+                valueSpan.style.cursor = 'ew-resize';
+                valueSpan.style.color = '#0066cc';
+                valueSpan.style.textDecoration = 'underline';
+                valueSpan.style.userSelect = 'none';
+                valueSpan.style.display = 'inline-block';
+                
+                try {
+                    katex.render(formattedValue, valueSpan, {
+                        throwOnError: false,
+                        displayMode: false,
+                    });
+                } catch (e) {
+                    valueSpan.textContent = formattedValue;
+                }
+                
+                // Make children non-interactive so clicks bubble to parent
+                const children = valueSpan.querySelectorAll('*');
+                children.forEach(child => {
+                    child.style.pointerEvents = 'none';
+                });
+                
+                valueSpan.addEventListener('mousedown', startDragging);
+                formulaDiv.appendChild(valueSpan);
+            }
+        });
 
         el.appendChild(formulaDiv);
     }
 
-    function makeValuesDraggable(container, placeholderMap, values, digits) {
-        // Strategy: Recursively find elements whose text content exactly matches our values
-        // KaTeX renders \textcolor{blue}{\underline{value}} - we need to find those elements
-        
-        function findElementWithText(node, targetText) {
-            // Check if this node's text matches
-            if (node.nodeType === Node.ELEMENT_NODE) {
-                const text = node.textContent.trim();
-                const normalizedText = text.replace(/\s+/g, ' ');
-                const normalizedTarget = targetText.replace(/\s+/g, ' ');
-                
-                if (normalizedText === normalizedTarget) {
-                    // Check if any child also matches exactly (prefer child)
-                    const children = Array.from(node.childNodes);
-                    for (let child of children) {
-                        if (child.nodeType === Node.ELEMENT_NODE) {
-                            const childText = child.textContent.trim().replace(/\s+/g, ' ');
-                            if (childText === normalizedTarget) {
-                                const found = findElementWithText(child, targetText);
-                                if (found) return found;
-                            }
-                        }
-                    }
-                    // No child matches exactly, so this is the element
-                    return node;
-                }
-            }
-            return null;
-        }
-        
-        Object.keys(placeholderMap).forEach(formattedValue => {
-            const placeholderName = placeholderMap[formattedValue];
-            
-            // Find the element containing this exact value
-            const element = findElementWithText(container, formattedValue);
-            
-            if (element && !element.classList.contains('formula-draggable')) {
-                // Check if it's already inside a draggable
-                let parent = element.parentElement;
-                let isInsideDraggable = false;
-                while (parent && parent !== container) {
-                    if (parent.classList.contains('formula-draggable')) {
-                        isInsideDraggable = true;
-                        break;
-                    }
-                    parent = parent.parentElement;
-                }
-                
-                if (!isInsideDraggable) {
-                    makeElementDraggable(element, placeholderName);
-                }
-            }
-        });
-    }
-
-    function makeElementDraggable(element, placeholderName) {
-        // Mark element as draggable
-        element.classList.add('formula-draggable');
-        element.dataset.placeholder = placeholderName;
-        element.style.cursor = 'ew-resize';
-        element.style.color = '#0066cc';
-        element.style.textDecoration = 'underline';
-        element.style.userSelect = 'none';
-        
-        // Disable pointer events on children so clicks bubble to this element
-        const children = element.querySelectorAll('*');
-        children.forEach(child => {
-            child.style.pointerEvents = 'none';
-        });
-        
-        element.addEventListener('mousedown', startDragging);
-    }
 
     function startDragging(e) {
         e.preventDefault();

--- a/wigglystuff/static/formula.js
+++ b/wigglystuff/static/formula.js
@@ -27,99 +27,124 @@ function render({model, el}) {
         el.innerHTML = '';
         el.classList.add("formula-container");
 
-        // Parse formula to find placeholders
-        const placeholderRegex = /\{(\w+)\}/g;
-        const parts = [];
-        let lastIndex = 0;
-        let match;
+        // Build LaTeX string with values substituted
+        // We'll use a unique class name via \class that we can find later
+        let latexString = formula;
+        const placeholderMap = {}; // Maps formatted value -> placeholder name
         
-        while ((match = placeholderRegex.exec(formula)) !== null) {
-            // Add text before placeholder
-            if (match.index > lastIndex) {
-                parts.push({
-                    type: 'latex',
-                    content: formula.substring(lastIndex, match.index)
-                });
-            }
-            // Add placeholder
-            parts.push({
-                type: 'placeholder',
-                name: match[1],
-                content: match[0]
-            });
-            lastIndex = match.index + match[0].length;
-        }
-        // Add remaining text
-        if (lastIndex < formula.length) {
-            parts.push({
-                type: 'latex',
-                content: formula.substring(lastIndex)
-            });
-        }
+        Object.keys(values).forEach(placeholderName => {
+            const value = values[placeholderName];
+            const decimalPlaces = digits[placeholderName] || 1;
+            const formattedValue = value.toFixed(decimalPlaces);
+            
+            // Replace placeholder with formatted value wrapped in a special class
+            // Use \class to add a data attribute we can find
+            const placeholderRegex = new RegExp(`\\{${placeholderName}\\}`, 'g');
+            // Use \textcolor and \class for styling and identification
+            latexString = latexString.replace(
+                placeholderRegex,
+                `\\textcolor{blue}{\\underline{${formattedValue}}}`
+            );
+            
+            // Store mapping for later
+            placeholderMap[formattedValue] = placeholderName;
+        });
 
         // Create container for formula
         const formulaDiv = document.createElement('div');
         formulaDiv.className = 'formula-display';
         formulaDiv.style.display = 'inline-block';
 
-        // Render each part
-        parts.forEach(part => {
-            if (part.type === 'latex') {
-                if (part.content.trim()) {
-                    const latexSpan = document.createElement('span');
-                    latexSpan.style.display = 'inline-block';
-                    try {
-                        katex.render(part.content, latexSpan, {
-                            throwOnError: false,
-                            displayMode: false,
-                        });
-                    } catch (e) {
-                        console.error('KaTeX rendering error:', e);
-                        latexSpan.textContent = part.content;
-                    }
-                    formulaDiv.appendChild(latexSpan);
-                }
-            } else if (part.type === 'placeholder') {
-                // Create draggable value element
-                const valueSpan = document.createElement('span');
-                valueSpan.className = 'formula-draggable';
-                valueSpan.dataset.placeholder = part.name;
-                const value = values[part.name];
-                const decimalPlaces = digits[part.name] || 1;
-                const formattedValue = value.toFixed(decimalPlaces);
-                
-                // Set styles before rendering (KaTeX preserves them)
-                valueSpan.style.cursor = 'ew-resize';
-                valueSpan.style.color = '#0066cc';
-                valueSpan.style.textDecoration = 'underline';
-                valueSpan.style.userSelect = 'none';
-                valueSpan.style.display = 'inline-block';
-                valueSpan.style.position = 'relative';
-                
-                // Render the number with KaTeX for consistent styling
-                try {
-                    katex.render(formattedValue, valueSpan, {
-                        throwOnError: false,
-                        displayMode: false,
-                    });
-                } catch (e) {
-                    valueSpan.textContent = formattedValue;
-                }
-                
-                // Ensure all child elements are also styled and clickable
-                const allChildren = valueSpan.querySelectorAll('*');
-                allChildren.forEach(child => {
-                    child.style.pointerEvents = 'none'; // Let clicks bubble to parent
-                });
-                
-                // Add event listener to the span (works for clicks on children too)
-                valueSpan.addEventListener('mousedown', startDragging);
-                
-                formulaDiv.appendChild(valueSpan);
-            }
-        });
+        // Render the entire formula as one LaTeX expression
+        try {
+            katex.render(latexString, formulaDiv, {
+                throwOnError: false,
+                displayMode: false,
+            });
+        } catch (e) {
+            console.error('KaTeX rendering error:', e);
+            formulaDiv.textContent = latexString;
+        }
+
+        // Now find and make draggable the numbers we marked
+        // KaTeX renders \textcolor{blue}{\underline{value}} as spans with specific styling
+        // We need to find elements that contain our formatted values
+        makeValuesDraggable(formulaDiv, placeholderMap, values, digits);
 
         el.appendChild(formulaDiv);
+    }
+
+    function makeValuesDraggable(container, placeholderMap, values, digits) {
+        // Strategy: Recursively find elements whose text content exactly matches our values
+        // KaTeX renders \textcolor{blue}{\underline{value}} - we need to find those elements
+        
+        function findElementWithText(node, targetText) {
+            // Check if this node's text matches
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                const text = node.textContent.trim();
+                const normalizedText = text.replace(/\s+/g, ' ');
+                const normalizedTarget = targetText.replace(/\s+/g, ' ');
+                
+                if (normalizedText === normalizedTarget) {
+                    // Check if any child also matches exactly (prefer child)
+                    const children = Array.from(node.childNodes);
+                    for (let child of children) {
+                        if (child.nodeType === Node.ELEMENT_NODE) {
+                            const childText = child.textContent.trim().replace(/\s+/g, ' ');
+                            if (childText === normalizedTarget) {
+                                const found = findElementWithText(child, targetText);
+                                if (found) return found;
+                            }
+                        }
+                    }
+                    // No child matches exactly, so this is the element
+                    return node;
+                }
+            }
+            return null;
+        }
+        
+        Object.keys(placeholderMap).forEach(formattedValue => {
+            const placeholderName = placeholderMap[formattedValue];
+            
+            // Find the element containing this exact value
+            const element = findElementWithText(container, formattedValue);
+            
+            if (element && !element.classList.contains('formula-draggable')) {
+                // Check if it's already inside a draggable
+                let parent = element.parentElement;
+                let isInsideDraggable = false;
+                while (parent && parent !== container) {
+                    if (parent.classList.contains('formula-draggable')) {
+                        isInsideDraggable = true;
+                        break;
+                    }
+                    parent = parent.parentElement;
+                }
+                
+                if (!isInsideDraggable) {
+                    makeElementDraggable(element, placeholderName);
+                }
+            }
+        });
+    }
+
+    function makeElementDraggable(element, placeholderName) {
+        // Mark element as draggable
+        element.classList.add('formula-draggable');
+        element.dataset.placeholder = placeholderName;
+        element.style.cursor = 'ew-resize';
+        element.style.color = '#0066cc';
+        element.style.textDecoration = 'underline';
+        element.style.userSelect = 'none';
+        
+        // Disable pointer events on children so clicks bubble to this element
+        const children = element.querySelectorAll('*');
+        children.forEach(child => {
+            child.style.pointerEvents = 'none';
+        });
+        
+        element.addEventListener('mousedown', startDragging);
     }
 
     function startDragging(e) {

--- a/wigglystuff/static/formula.js
+++ b/wigglystuff/static/formula.js
@@ -1,0 +1,217 @@
+function render({model, el}) {
+    // Load KaTeX if not already loaded
+    if (!window.katex) {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css';
+        document.head.appendChild(link);
+        
+        const script = document.createElement('script');
+        script.src = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js';
+        script.onload = () => renderFormula();
+        document.head.appendChild(script);
+    } else {
+        renderFormula();
+    }
+
+    function renderFormula() {
+        const formula = model.get("formula");
+        const values = model.get("values");
+        const minValues = model.get("min_values");
+        const maxValues = model.get("max_values");
+        const stepSizes = model.get("step_sizes");
+        const digits = model.get("digits");
+        const pixelsPerStep = model.get("pixels_per_step");
+
+        // Clear container
+        el.innerHTML = '';
+        el.classList.add("formula-container");
+
+        // Parse formula to find placeholders
+        const placeholderRegex = /\{(\w+)\}/g;
+        const parts = [];
+        let lastIndex = 0;
+        let match;
+        
+        while ((match = placeholderRegex.exec(formula)) !== null) {
+            // Add text before placeholder
+            if (match.index > lastIndex) {
+                parts.push({
+                    type: 'latex',
+                    content: formula.substring(lastIndex, match.index)
+                });
+            }
+            // Add placeholder
+            parts.push({
+                type: 'placeholder',
+                name: match[1],
+                content: match[0]
+            });
+            lastIndex = match.index + match[0].length;
+        }
+        // Add remaining text
+        if (lastIndex < formula.length) {
+            parts.push({
+                type: 'latex',
+                content: formula.substring(lastIndex)
+            });
+        }
+
+        // Create container for formula
+        const formulaDiv = document.createElement('div');
+        formulaDiv.className = 'formula-display';
+        formulaDiv.style.display = 'inline-block';
+
+        // Render each part
+        parts.forEach(part => {
+            if (part.type === 'latex') {
+                if (part.content.trim()) {
+                    const latexSpan = document.createElement('span');
+                    latexSpan.style.display = 'inline-block';
+                    try {
+                        katex.render(part.content, latexSpan, {
+                            throwOnError: false,
+                            displayMode: false,
+                        });
+                    } catch (e) {
+                        console.error('KaTeX rendering error:', e);
+                        latexSpan.textContent = part.content;
+                    }
+                    formulaDiv.appendChild(latexSpan);
+                }
+            } else if (part.type === 'placeholder') {
+                // Create draggable value element
+                const valueSpan = document.createElement('span');
+                valueSpan.className = 'formula-draggable';
+                valueSpan.dataset.placeholder = part.name;
+                const value = values[part.name];
+                const decimalPlaces = digits[part.name] || 1;
+                const formattedValue = value.toFixed(decimalPlaces);
+                
+                // Set styles before rendering (KaTeX preserves them)
+                valueSpan.style.cursor = 'ew-resize';
+                valueSpan.style.color = '#0066cc';
+                valueSpan.style.textDecoration = 'underline';
+                valueSpan.style.userSelect = 'none';
+                valueSpan.style.display = 'inline-block';
+                valueSpan.style.position = 'relative';
+                
+                // Render the number with KaTeX for consistent styling
+                try {
+                    katex.render(formattedValue, valueSpan, {
+                        throwOnError: false,
+                        displayMode: false,
+                    });
+                } catch (e) {
+                    valueSpan.textContent = formattedValue;
+                }
+                
+                // Ensure all child elements are also styled and clickable
+                const allChildren = valueSpan.querySelectorAll('*');
+                allChildren.forEach(child => {
+                    child.style.pointerEvents = 'none'; // Let clicks bubble to parent
+                });
+                
+                // Add event listener to the span (works for clicks on children too)
+                valueSpan.addEventListener('mousedown', startDragging);
+                
+                formulaDiv.appendChild(valueSpan);
+            }
+        });
+
+        el.appendChild(formulaDiv);
+    }
+
+    function startDragging(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        
+        // Find the draggable element (might be clicked on a child element)
+        let element = e.target;
+        while (element && !element.dataset.placeholder) {
+            element = element.parentElement;
+        }
+        
+        if (!element || !element.dataset.placeholder) return;
+        
+        const placeholderName = element.dataset.placeholder;
+
+        const values = model.get("values");
+        const minValues = model.get("min_values");
+        const maxValues = model.get("max_values");
+        const stepSizes = model.get("step_sizes");
+        const digits = model.get("digits");
+        const pixelsPerStep = model.get("pixels_per_step");
+
+        const startX = e.clientX;
+        const startValue = values[placeholderName];
+        const minValue = minValues[placeholderName];
+        const maxValue = maxValues[placeholderName];
+        const stepSize = stepSizes[placeholderName];
+        const decimalPlaces = digits[placeholderName] || 1;
+
+        element.style.cursor = 'grabbing';
+
+        let updateTimeout;
+        function debouncedUpdate() {
+            clearTimeout(updateTimeout);
+            updateTimeout = setTimeout(() => {
+                model.save_changes();
+            }, 50);
+        }
+
+        function onMouseMove(e) {
+            const deltaX = e.clientX - startX;
+            const steps = Math.floor(deltaX / pixelsPerStep);
+            const newValue = Math.max(
+                minValue,
+                Math.min(maxValue, startValue + steps * stepSize)
+            );
+            
+            // Update values
+            const updatedValues = {...values};
+            updatedValues[placeholderName] = parseFloat(newValue.toFixed(10));
+            model.set("values", updatedValues);
+            
+            // Re-render formula with new value
+            renderFormula();
+            debouncedUpdate();
+        }
+
+        function onMouseUp() {
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+            model.save_changes();
+        }
+
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+    }
+
+    // Listen for model changes
+    model.on('change:formula', () => {
+        if (window.katex) renderFormula();
+    });
+    model.on('change:values', () => {
+        if (window.katex) renderFormula();
+    });
+    model.on('change:min_values', () => {
+        if (window.katex) renderFormula();
+    });
+    model.on('change:max_values', () => {
+        if (window.katex) renderFormula();
+    });
+    model.on('change:step_sizes', () => {
+        if (window.katex) renderFormula();
+    });
+    model.on('change:digits', () => {
+        if (window.katex) renderFormula();
+    });
+
+    // Initial render
+    if (window.katex) {
+        renderFormula();
+    }
+}
+
+export default { render };


### PR DESCRIPTION
Add a new `Formula` widget to render interactive LaTeX formulas with draggable numbers.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe865553-bbd2-43d0-9e44-28ae5524dd26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe865553-bbd2-43d0-9e44-28ae5524dd26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

