### PR TITLE
Latex formula widget

### DIFF
--- a/demos/latex_formula.py
+++ b/demos/latex_formula.py
@@ -1,0 +1,159 @@
+import marimo
+
+__generated_with = "0.18.2"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from wigglystuff import LatexFormula, Matrix
+    return LatexFormula, Matrix, mo
+
+
+@app.cell
+def _(LatexFormula, mo):
+    # Simple formula example
+    simple_formula = LatexFormula(
+        parts=["x^2 + y^2 = r^2"],
+        font_size=20
+    )
+    
+    mo.vstack([
+        mo.md("### Simple LaTeX Formula"),
+        simple_formula,
+    ])
+    return simple_formula,
+
+
+@app.cell
+def _(LatexFormula, mo):
+    # Chained parts example
+    chained_formula = LatexFormula(
+        parts=[
+            "A",
+            "=",
+            "\\begin{pmatrix} 1 & 2 \\\\ 3 & 4 \\end{pmatrix}"
+        ],
+        font_size=18
+    )
+    
+    mo.vstack([
+        mo.md("### Chained Formula Parts"),
+        chained_formula,
+    ])
+    return chained_formula,
+
+
+@app.cell
+def _(LatexFormula, Matrix, mo):
+    # Integration with Matrix widget
+    matrix = Matrix(rows=2, cols=2, min_value=-10, max_value=10, step=0.1)
+    
+    # Formula that references the matrix
+    formula_with_matrix = LatexFormula(
+        parts=[
+            "A",
+            "=",
+            "\\begin{pmatrix}",
+            f"{matrix.matrix[0][0]:.2f}",
+            "&",
+            f"{matrix.matrix[0][1]:.2f}",
+            "\\\\",
+            f"{matrix.matrix[1][0]:.2f}",
+            "&",
+            f"{matrix.matrix[1][1]:.2f}",
+            "\\end{pmatrix}"
+        ],
+        font_size=18
+    )
+    
+    mo.vstack([
+        mo.md("### Formula with Matrix Widget"),
+        mo.md("Edit the matrix below and see the formula update:"),
+        mo.hstack([matrix, formula_with_matrix]),
+    ])
+    return formula_with_matrix, matrix
+
+
+@app.cell
+def _(LatexFormula, mo):
+    # Complex formula example
+    complex_formula = LatexFormula(
+        parts=[
+            "\\int_{-\\infty}^{\\infty}",
+            "e^{-x^2}",
+            "dx",
+            "=",
+            "\\sqrt{\\pi}"
+        ],
+        font_size=20,
+        display_mode=True
+    )
+    
+    mo.vstack([
+        mo.md("### Complex Formula (Display Mode)"),
+        complex_formula,
+    ])
+    return complex_formula,
+
+
+@app.cell
+def _(LatexFormula, mo):
+    # Multiple formulas chained together
+    formula1 = LatexFormula(parts=["f(x) = x^2 + 2x + 1"], font_size=16)
+    formula2 = LatexFormula(parts=["g(x) = \\sin(x)"], font_size=16)
+    formula3 = LatexFormula(
+        parts=["h(x) = f(x) \\cdot g(x)"],
+        font_size=16
+    )
+    
+    mo.vstack([
+        mo.md("### Multiple Formulas"),
+        formula1,
+        mo.md("and"),
+        formula2,
+        mo.md("combine to form:"),
+        formula3,
+    ])
+    return formula1, formula2, formula3
+
+
+@app.cell
+def _(LatexFormula, mo):
+    # Dynamic formula example
+    import numpy as np
+    
+    # Create a formula that can be updated
+    dynamic_formula = LatexFormula(
+        parts=[
+            "\\sum_{i=1}^{n}",
+            "x_i",
+            "=",
+            "0"
+        ],
+        font_size=18
+    )
+    
+    # Example: Update formula based on some computation
+    n = 5
+    values = np.random.randn(n)
+    sum_val = np.sum(values)
+    
+    dynamic_formula.set_parts([
+        "\\sum_{i=1}^{" + str(n) + "}",
+        "x_i",
+        "=",
+        f"{sum_val:.2f}"
+    ])
+    
+    mo.vstack([
+        mo.md("### Dynamic Formula"),
+        mo.md(f"For n={n} random values:"),
+        dynamic_formula,
+    ])
+    return dynamic_formula, n, sum_val, values
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - GamepadWidget: reference/gamepad.md
       - WebcamCapture: reference/webcam-capture.md
       - CellTour: reference/cell-tour.md
+      - LatexFormula: reference/latex-formula.md
 plugins:
   - search
   - section-index

--- a/mkdocs/reference/index.md
+++ b/mkdocs/reference/index.md
@@ -15,3 +15,4 @@ Browse widget-specific reference pages below. Each page is generated automatical
 - [GamepadWidget](gamepad.md)
 - [CellTour](cell-tour.md)
 - [WebcamCapture](webcam-capture.md)
+- [LatexFormula](latex-formula.md)

--- a/mkdocs/reference/latex-formula.md
+++ b/mkdocs/reference/latex-formula.md
@@ -1,0 +1,85 @@
+# LatexFormula API
+
+::: wigglystuff.latex_formula.LatexFormula
+
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `parts` | `list[str]` | List of LaTeX strings to render. Parts are rendered sequentially and can be chained together. |
+| `font_size` | `float` | Font size in pixels for the formula. |
+| `display_mode` | `bool` | If True, renders as a block (centered, larger spacing). If False, renders inline. |
+
+## Examples
+
+### Simple Formula
+
+```python
+from wigglystuff import LatexFormula
+
+formula = LatexFormula(parts=["x^2 + y^2 = r^2"])
+```
+
+### Chained Parts
+
+You can chain multiple parts together to build complex formulas:
+
+```python
+formula = LatexFormula(
+    parts=[
+        "A",
+        "=",
+        "\\begin{pmatrix} 1 & 2 \\\\ 3 & 4 \\end{pmatrix}"
+    ]
+)
+```
+
+### Display Mode
+
+Use display mode for centered, block-level formulas:
+
+```python
+formula = LatexFormula(
+    parts=["\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}"],
+    display_mode=True
+)
+```
+
+### Integration with Matrix Widget
+
+You can combine LaTeX formulas with Matrix widgets:
+
+```python
+from wigglystuff import LatexFormula, Matrix
+
+matrix = Matrix(rows=2, cols=2)
+formula = LatexFormula(
+    parts=[
+        "A",
+        "=",
+        "\\begin{pmatrix}",
+        f"{matrix.matrix[0][0]:.2f}",
+        "&",
+        f"{matrix.matrix[0][1]:.2f}",
+        "\\\\",
+        f"{matrix.matrix[1][0]:.2f}",
+        "&",
+        f"{matrix.matrix[1][1]:.2f}",
+        "\\end{pmatrix}"
+    ]
+)
+```
+
+### Dynamic Updates
+
+You can update formula parts programmatically:
+
+```python
+formula = LatexFormula(parts=["f(x) = x^2"])
+
+# Add a new part
+formula.add_part(" + 2x + 1")
+
+# Or replace all parts
+formula.set_parts(["f(x) = x^3 + x"])
+```

--- a/wigglystuff/__init__.py
+++ b/wigglystuff/__init__.py
@@ -7,6 +7,7 @@ from .driver_tour import DriverTour
 from .edge_draw import EdgeDraw
 from .gamepad import GamepadWidget
 from .keystroke import KeystrokeWidget
+from .latex_formula import LatexFormula
 from .matrix import Matrix
 from .paint import Paint
 from .slider2d import Slider2D
@@ -23,6 +24,7 @@ __all__ = [
     "EdgeDraw",
     "GamepadWidget",
     "KeystrokeWidget",
+    "LatexFormula",
     "Matrix",
     "Paint",
     "Slider2D",

--- a/wigglystuff/latex_formula.py
+++ b/wigglystuff/latex_formula.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+from typing import Any, List, Optional
+
+import anywidget
+import traitlets
+
+
+class LatexFormula(anywidget.AnyWidget):
+    """Widget for rendering large LaTeX formulas with support for chaining parts.
+
+    This widget can render LaTeX formulas and chain together multiple parts.
+    It can also integrate with other widgets like Matrix for displaying
+    matrices within formulas.
+
+    Examples:
+        ```python
+        # Simple formula
+        formula = LatexFormula(parts=["x^2 + y^2 = r^2"])
+        
+        # Chained parts
+        formula = LatexFormula(parts=["A", "=", "\\begin{pmatrix} 1 & 2 \\\\ 3 & 4 \\end{pmatrix}"])
+        
+        # With matrix widget integration
+        from wigglystuff import Matrix
+        matrix = Matrix(rows=2, cols=2)
+        # Use matrix values in formula parts
+        formula = LatexFormula(parts=["A", "=", f"\\begin{{pmatrix}} {matrix.matrix[0][0]} & {matrix.matrix[0][1]} \\\\ {matrix.matrix[1][0]} & {matrix.matrix[1][1]} \\end{{pmatrix}}"])
+        ```
+    """
+
+    _esm = Path(__file__).parent / "static" / "latex_formula.js"
+    _css = Path(__file__).parent / "static" / "latex_formula.css"
+    parts = traitlets.List([]).tag(sync=True)
+    font_size = traitlets.Float(16.0).tag(sync=True)
+    display_mode = traitlets.Bool(False).tag(sync=True)  # True for block, False for inline
+
+    def __init__(
+        self,
+        parts: Optional[List[str]] = None,
+        font_size: float = 16.0,
+        display_mode: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Create a LaTeX formula widget.
+
+        Args:
+            parts: List of LaTeX strings to render. Parts are rendered sequentially
+                and can be chained together. Use empty strings for spacing.
+            font_size: Font size in pixels for the formula.
+            display_mode: If True, renders as a block (centered, larger spacing).
+                If False, renders inline.
+            **kwargs: Forwarded to ``anywidget.AnyWidget``.
+        """
+        if parts is None:
+            parts = [""]
+
+        super().__init__(
+            parts=parts,
+            font_size=font_size,
+            display_mode=display_mode,
+            **kwargs,
+        )
+
+    def add_part(self, part: str) -> None:
+        """Add a new part to the formula.
+
+        Args:
+            part: LaTeX string to add.
+        """
+        current_parts = list(self.parts)
+        current_parts.append(part)
+        self.parts = current_parts
+
+    def set_parts(self, parts: List[str]) -> None:
+        """Replace all parts with a new list.
+
+        Args:
+            parts: New list of LaTeX strings.
+        """
+        self.parts = parts

--- a/wigglystuff/static/latex_formula.css
+++ b/wigglystuff/static/latex_formula.css
@@ -1,0 +1,52 @@
+.latex-formula-wrapper {
+    display: inline-block;
+    font-family: 'KaTeX_Main', 'Times New Roman', serif;
+    line-height: 1.2;
+    color: inherit;
+}
+
+.latex-formula-display {
+    display: block;
+    text-align: center;
+    margin: 1em 0;
+    padding: 0.5em 0;
+}
+
+.latex-formula-container {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.2em;
+}
+
+.latex-formula-part {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.latex-formula-spacer {
+    display: inline-block;
+}
+
+.latex-formula-error {
+    color: #dc2626;
+    font-family: monospace;
+    font-size: 0.9em;
+    padding: 0.2em 0.4em;
+    background-color: rgba(220, 38, 38, 0.1);
+    border-radius: 3px;
+}
+
+/* Dark mode support */
+.dark .latex-formula-wrapper,
+.dark-theme .latex-formula-wrapper,
+[data-theme="dark"] .latex-formula-wrapper {
+    color: inherit;
+}
+
+.dark .latex-formula-error,
+.dark-theme .latex-formula-error,
+[data-theme="dark"] .latex-formula-error {
+    color: #f87171;
+    background-color: rgba(248, 113, 113, 0.15);
+}

--- a/wigglystuff/static/latex_formula.js
+++ b/wigglystuff/static/latex_formula.js
@@ -1,0 +1,109 @@
+function render({model, el}) {
+    const parts = model.get("parts") || [];
+    const fontSize = model.get("font_size") || 16;
+    const displayMode = model.get("display_mode") || false;
+
+    // Load KaTeX CSS and JS if not already loaded
+    function loadKaTeX() {
+        return new Promise((resolve) => {
+            // Check if KaTeX is already loaded
+            if (window.katex) {
+                resolve();
+                return;
+            }
+
+            // Load KaTeX CSS
+            const cssLink = document.createElement('link');
+            cssLink.rel = 'stylesheet';
+            cssLink.href = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css';
+            cssLink.integrity = 'sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kT6GFkOoRvnM';
+            cssLink.crossOrigin = 'anonymous';
+            document.head.appendChild(cssLink);
+
+            // Load KaTeX JS
+            const script = document.createElement('script');
+            script.src = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js';
+            script.integrity = 'sha384-XjKyOOzGXjqAgfq6Aw3u6PsHvLa1D9c3qU7DAuU9Dsskk2vvgY0z6U6Cy6u2mz';
+            script.crossOrigin = 'anonymous';
+            script.onload = resolve;
+            document.head.appendChild(script);
+        });
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('latex-formula-wrapper');
+    wrapper.style.fontSize = `${fontSize}px`;
+    if (displayMode) {
+        wrapper.classList.add('latex-formula-display');
+    }
+    el.appendChild(wrapper);
+
+    function renderFormula() {
+        wrapper.innerHTML = '';
+        
+        if (!window.katex) {
+            loadKaTeX().then(() => {
+                renderFormula();
+            });
+            return;
+        }
+
+        const container = document.createElement('div');
+        container.classList.add('latex-formula-container');
+        
+        parts.forEach((part, index) => {
+            if (!part || part.trim() === '') {
+                // Add spacing for empty parts
+                const spacer = document.createElement('span');
+                spacer.classList.add('latex-formula-spacer');
+                spacer.style.display = 'inline-block';
+                spacer.style.width = '0.5em';
+                container.appendChild(spacer);
+                return;
+            }
+
+            const partElement = document.createElement('span');
+            partElement.classList.add('latex-formula-part');
+            
+            try {
+                window.katex.render(part, partElement, {
+                    throwOnError: false,
+                    displayMode: displayMode,
+                    strict: false,
+                });
+            } catch (error) {
+                // Fallback to plain text if LaTeX rendering fails
+                partElement.textContent = part;
+                partElement.classList.add('latex-formula-error');
+            }
+            
+            container.appendChild(partElement);
+        });
+
+        wrapper.appendChild(container);
+    }
+
+    // Initial render
+    renderFormula();
+
+    // Update when model changes
+    model.on('change:parts', () => {
+        renderFormula();
+    });
+
+    model.on('change:font_size', () => {
+        wrapper.style.fontSize = `${model.get('font_size')}px`;
+    });
+
+    model.on('change:display_mode', () => {
+        const newDisplayMode = model.get('display_mode');
+        if (newDisplayMode) {
+            wrapper.classList.add('latex-formula-display');
+        } else {
+            wrapper.classList.remove('latex-formula-display');
+        }
+        renderFormula();
+    });
+}
+
+export default { render };


### PR DESCRIPTION
Add a `LatexFormula` widget to render LaTeX expressions, supporting chained parts and integration with other widgets like `Matrix`.

---
<a href="https://cursor.com/background-agent?bcId=bc-036ac006-397d-4273-84a9-152311cd09a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-036ac006-397d-4273-84a9-152311cd09a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

