### PR TITLE
Add auto-rotation feature to ThreeWidget

### DIFF
--- a/demos/threewidget.py
+++ b/demos/threewidget.py
@@ -79,6 +79,12 @@ def _(data, random, three):
 
 
 @app.cell
+def _(widget):
+    widget.start_rotate(speed=1.0)
+    return
+
+
+@app.cell
 def _():
     return
 

--- a/uv.lock
+++ b/uv.lock
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/static/three-widget.js
+++ b/wigglystuff/static/three-widget.js
@@ -20747,9 +20747,14 @@ function render({ model, el }) {
   const controls = new OrbitControls(camera, renderer.domElement);
   controls.enableDamping = true;
   controls.dampingFactor = 0.05;
+  controls.autoRotate = model.get("auto_rotate");
+  controls.autoRotateSpeed = model.get("auto_rotate_speed");
   let userHasInteracted = false;
   controls.addEventListener("start", () => {
     userHasInteracted = true;
+    controls.autoRotate = false;
+    model.set("auto_rotate", false);
+    model.save_changes();
   });
   const ambientLight = new AmbientLight(16777215, darkMode ? 0.4 : 0.6);
   scene.add(ambientLight);
@@ -21130,6 +21135,15 @@ function render({ model, el }) {
   model.on("change:axis_labels", () => {
     updateAxisLabels();
     updateAxisLabelPositions();
+  });
+  model.on("change:auto_rotate", () => {
+    const shouldRotate = model.get("auto_rotate");
+    if (shouldRotate) {
+      controls.autoRotate = true;
+    }
+  });
+  model.on("change:auto_rotate_speed", () => {
+    controls.autoRotateSpeed = model.get("auto_rotate_speed");
   });
   let animationId;
   function animate() {

--- a/wigglystuff/three_widget.py
+++ b/wigglystuff/three_widget.py
@@ -36,6 +36,8 @@ class ThreeWidget(anywidget.AnyWidget):
     axis_labels = traitlets.List(traitlets.Unicode(), default_value=[]).tag(sync=True)
     animate_updates = traitlets.Bool(False).tag(sync=True)
     animation_duration_ms = traitlets.Int(400).tag(sync=True)
+    auto_rotate = traitlets.Bool(False).tag(sync=True)
+    auto_rotate_speed = traitlets.Float(2.0).tag(sync=True)
 
     def __init__(
         self,
@@ -49,6 +51,8 @@ class ThreeWidget(anywidget.AnyWidget):
         axis_labels: Optional[Iterable[str]] = None,
         animate_updates: bool = False,
         animation_duration_ms: int = 400,
+        auto_rotate: bool = False,
+        auto_rotate_speed: float = 2.0,
         **kwargs: Any,
     ) -> None:
         """Create a ThreeWidget.
@@ -64,6 +68,8 @@ class ThreeWidget(anywidget.AnyWidget):
             axis_labels: Optional axis labels for x/y/z.
             animate_updates: Whether to animate point updates.
             animation_duration_ms: Animation duration in milliseconds.
+            auto_rotate: Whether to start with automatic rotation enabled.
+            auto_rotate_speed: Speed of automatic rotation.
             **kwargs: Forwarded to ``anywidget.AnyWidget``.
         """
         super().__init__(
@@ -76,6 +82,8 @@ class ThreeWidget(anywidget.AnyWidget):
             axis_labels=list(axis_labels) if axis_labels is not None else [],
             animate_updates=animate_updates,
             animation_duration_ms=animation_duration_ms,
+            auto_rotate=auto_rotate,
+            auto_rotate_speed=auto_rotate_speed,
             **kwargs,
         )
 
@@ -111,3 +119,14 @@ class ThreeWidget(anywidget.AnyWidget):
             self.animation_duration_ms = duration_ms
         self.animate_updates = animate
         self.data = merged
+
+    def start_rotate(self, speed: float = 2.0) -> None:
+        """Start automatic rotation around the center of all points.
+
+        Rotation stops when the user interacts with the widget.
+
+        Args:
+            speed: Speed of automatic rotation.
+        """
+        self.auto_rotate_speed = speed
+        self.auto_rotate = True


### PR DESCRIPTION
## Summary
- Adds `start_rotate()` method to enable automatic rotation around centerpoint of all points
- Rotation speed controllable via parameter or `auto_rotate_speed` property
- Supports both constructor parameter and method invocation
- Automatically stops when user interacts with the widget

## Test plan
- Create ThreeWidget with sample data and call `start_rotate()`
- Verify rotation around center point
- Test interaction stops rotation
- Test with different speeds via `start_rotate(speed=X)`

🤖 Generated with Claude Code