### PR TITLE
Fix Slider2D infinite recursion on latest marimo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.10] - 2026-01-07
+
+### Fixed
+- Fixed "Maximum call stack size exceeded" error when rendering `Slider2D` widget on latest marimo. The widget had an infinite loop where model change handlers would trigger redraws that updated the model again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.9"
+version = "0.2.10"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/static/2dslider.js
+++ b/wigglystuff/static/2dslider.js
@@ -4,10 +4,10 @@ function render({ model, el }) {
   canvas.setAttribute("width", model.get("width").toString());
   canvas.setAttribute("height", model.get("height").toString());
   canvas.setAttribute("style", "border: 1px solid #ccc; background: #eee;");
-  
+
   const sliderValuesDiv = document.createElement("div");
   sliderValuesDiv.setAttribute("id", "sliderValues");
-  
+
   el.appendChild(canvas);
   el.appendChild(sliderValuesDiv);
 
@@ -21,7 +21,7 @@ function render({ model, el }) {
   let currentX = 0;
   let currentY = 0;
 
-  function drawSlider() {
+  function drawSlider(updateModel = true) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
       ctx.beginPath();
@@ -39,9 +39,11 @@ function render({ model, el }) {
       const mappedY = y_min + ((-currentY / radius) + 1) / 2 * (y_max - y_min); // Y is inverted
 
       sliderValuesDiv.textContent = `X: ${mappedX.toFixed(2)}, Y: ${mappedY.toFixed(2)}`;
-      model.set('x', mappedX);
-      model.set('y', mappedY);
-      model.save_changes();
+      if (updateModel) {
+        model.set('x', mappedX);
+        model.set('y', mappedY);
+        model.save_changes();
+      }
   }
 
   function syncFromModel() {
@@ -53,9 +55,9 @@ function render({ model, el }) {
       // Inverse mapping from user coordinates to pixel coordinates
       currentX = radius * (2 * (modelX - x_min) / (x_max - x_min) - 1);
       currentY = -radius * (2 * (modelY - y_min) / (y_max - y_min) - 1); // Y is inverted
-      
+
       if (!isDragging) {
-        drawSlider();
+        drawSlider(false);  // Don't update model when syncing from model
       }
   }
 


### PR DESCRIPTION
## Summary
- Fix "Maximum call stack size exceeded" error when rendering Slider2D widget on latest marimo
- The issue was an infinite loop: `syncFromModel()` → `drawSlider()` → `model.set()` → triggers change event → `syncFromModel()` → ...
- Added `updateModel` parameter to `drawSlider()` to skip model updates when syncing from model state

## Test plan
- [ ] Render `Slider2D()` widget in latest marimo - should no longer show stack overflow error
- [ ] Drag the slider - values should update correctly
- [ ] Set `x`/`y` values programmatically - slider should reflect the new position

🤖 Generated with [Claude Code](https://claude.com/claude-code)