### PR TITLE
Add llms.txt support and enhance API docs

### DIFF
--- a/mkdocs/llms.txt
+++ b/mkdocs/llms.txt
@@ -1,0 +1,29 @@
+# wigglystuff
+
+> A collection of creative AnyWidgets for Python notebook environments like Jupyter, marimo, Shiny, and Colab.
+
+Install via `pip install wigglystuff` or `uv pip install wigglystuff`.
+
+## Widgets
+
+- [Slider2D](https://koaning.github.io/wigglystuff/reference/slider2d.md): 2D slider for x/y value selection
+- [Matrix](https://koaning.github.io/wigglystuff/reference/matrix.md): Interactive matrix input
+- [SortableList](https://koaning.github.io/wigglystuff/reference/sortable-list.md): Drag-and-drop sortable list
+- [Paint](https://koaning.github.io/wigglystuff/reference/paint.md): Drawing canvas widget
+- [ThreeWidget](https://koaning.github.io/wigglystuff/reference/three-widget.md): 3D visualization with Three.js
+- [EdgeDraw](https://koaning.github.io/wigglystuff/reference/edge-draw.md): Edge/graph drawing widget
+- [KeystrokeWidget](https://koaning.github.io/wigglystuff/reference/keystroke.md): Keyboard input capture
+- [WebkitSpeechToText](https://koaning.github.io/wigglystuff/reference/talk.md): Speech-to-text input
+- [ColorPicker](https://koaning.github.io/wigglystuff/reference/color-picker.md): Color selection widget
+- [CopyToClipboard](https://koaning.github.io/wigglystuff/reference/copy-to-clipboard.md): Copy text to clipboard
+- [Tangle Widgets](https://koaning.github.io/wigglystuff/reference/tangle.md): Bret Victor-style tangle controls
+- [GamepadWidget](https://koaning.github.io/wigglystuff/reference/gamepad.md): Gamepad controller input
+- [WebcamCapture](https://koaning.github.io/wigglystuff/reference/webcam-capture.md): Webcam image capture
+- [CellTour](https://koaning.github.io/wigglystuff/reference/cell-tour.md): Guided notebook tours
+- [ImageRefreshWidget](https://koaning.github.io/wigglystuff/reference/image-refresh.md): Auto-refreshing images
+- [HTMLRefreshWidget](https://koaning.github.io/wigglystuff/reference/html-refresh.md): Auto-refreshing HTML content
+- [ProgressBar](https://koaning.github.io/wigglystuff/reference/progress-bar.md): Progress indicator widget
+
+## Optional
+
+- [Utils](https://koaning.github.io/wigglystuff/reference/utils.md): Utility functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,6 +2222,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2364,8 +2365,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -2704,6 +2704,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2950,6 +2951,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3184,6 +3186,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3348,8 +3351,7 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3528,6 +3530,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary

Added llms.txt file for LLM consumption and enhanced the API documentation generation process.

- **llms.txt**: New file providing a concise directory of all 17 widgets with descriptions and links to markdown documentation
- **API docs improvements**: Skip Parameters table in generated markdown, automatically prepend import statements to example code blocks, and include only essential information for LLM consumption

## Test plan

- [x] Verify llms.txt is accessible at `/llms.txt` when docs are built
- [x] Confirm Parameters table is removed from generated markdown files
- [x] Check that example code blocks include import statements (e.g., `from wigglystuff import Slider2D`)
- [x] Ensure Synced traitlets table is still present in generated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)