### PR TITLE
Update EnvConfig demo to show all_valid property

### DIFF
--- a/demos/envconfig.py
+++ b/demos/envconfig.py
@@ -84,7 +84,7 @@ def _(mo):
 
 @app.cell
 def _(config_validated):
-    config_validated.widget.all_valid
+    config_validated.all_valid
     return
 
 
@@ -98,7 +98,7 @@ def _(mo):
 
 @app.cell
 def _(config_validated):
-    config_validated.widget.require_valid()
+    config_validated.require_valid()
     return
 
 

--- a/demos/envconfig.py
+++ b/demos/envconfig.py
@@ -84,7 +84,21 @@ def _(mo):
 
 @app.cell
 def _(config_validated):
-    config_validated.require_valid()
+    config_validated.widget.all_valid
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    If you want to raise an error when the inputs are invalid, you can use `require_valid()`.
+    """)
+    return
+
+
+@app.cell
+def _(config_validated):
+    config_validated.widget.require_valid()
     return
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/uv.lock
+++ b/uv.lock
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.13"
+version = "0.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary
Updated the EnvConfig demo to show the `all_valid` property and separated `require_valid()` into its own cell with explanation.

## Changes
- Added a cell demonstrating the `all_valid` property
- Separated `require_valid()` into a dedicated cell with markdown explanation
- Updated version to 0.2.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)