### PR TITLE
Simplify browser tests: use fixture factory instead of parametrize

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -56,3 +56,6 @@ syncs back to Python.
 - Each widget has a demo marimo notebook in the `demos/` folder (e.g.,
   `demos/colorpicker.py`). When adding a new widget, create a corresponding
   demo notebook. Run demos with `marimo edit demos/<widget>.py`.
+- Dumber is better. Prefer obvious, direct code over clever abstractions—someone
+  new to the project should be able to read the code top-to-bottom and grok it
+  without needing to look up framework magic or trace through indirection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,7 +2222,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2365,7 +2364,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -2704,7 +2704,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2951,7 +2950,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3186,7 +3184,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3351,7 +3348,8 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3530,7 +3528,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",

--- a/tests/test_browser/test_sortable_list_browser.py
+++ b/tests/test_browser/test_sortable_list_browser.py
@@ -1,34 +1,27 @@
 """Playwright integration tests for SortableList widget."""
 
-import os
-import pytest
 from playwright.sync_api import Page, expect
 
-# Longer timeouts for CI
-WIDGET_TIMEOUT = 30000 if os.environ.get("CI") else 10000
 
-
-@pytest.mark.parametrize("marimo_server", ["demos/sortlist.py"], indirect=True)
-def test_sortable_list_renders(marimo_server: str, page: Page):
+def test_sortable_list_renders(start_marimo, page: Page):
     """Test that the SortableList widget renders in the browser."""
-    page.goto(marimo_server, wait_until="networkidle")
+    url = start_marimo("demos/sortlist.py")
+    page.goto(url, wait_until="networkidle")
 
-    # Wait for the widget to render
     widget = page.locator(".draggable-list-widget")
-    expect(widget).to_be_visible(timeout=WIDGET_TIMEOUT)
+    expect(widget).to_be_visible()
 
-    # Check that initial items are rendered
     items = page.locator(".list-item")
     expect(items).to_have_count(3)  # ["a", "b", "c"]
 
 
-@pytest.mark.parametrize("marimo_server", ["demos/sortlist.py"], indirect=True)
-def test_add_item_updates_list(marimo_server: str, page: Page):
+def test_add_item_updates_list(start_marimo, page: Page):
     """Test that adding an item via the input updates the widget."""
-    page.goto(marimo_server, wait_until="networkidle")
+    url = start_marimo("demos/sortlist.py")
+    page.goto(url, wait_until="networkidle")
 
     widget = page.locator(".draggable-list-widget")
-    expect(widget).to_be_visible(timeout=WIDGET_TIMEOUT)
+    expect(widget).to_be_visible()
 
     add_input = page.locator(".add-input")
     expect(add_input).to_be_visible()
@@ -43,13 +36,13 @@ def test_add_item_updates_list(marimo_server: str, page: Page):
     expect(new_item_label).to_be_visible()
 
 
-@pytest.mark.parametrize("marimo_server", ["demos/sortlist.py"], indirect=True)
-def test_remove_item_updates_list(marimo_server: str, page: Page):
+def test_remove_item_updates_list(start_marimo, page: Page):
     """Test that clicking remove button removes an item."""
-    page.goto(marimo_server, wait_until="networkidle")
+    url = start_marimo("demos/sortlist.py")
+    page.goto(url, wait_until="networkidle")
 
     widget = page.locator(".draggable-list-widget")
-    expect(widget).to_be_visible(timeout=WIDGET_TIMEOUT)
+    expect(widget).to_be_visible()
 
     items = page.locator(".list-item")
     expect(items).to_have_count(3)
@@ -60,13 +53,13 @@ def test_remove_item_updates_list(marimo_server: str, page: Page):
     expect(items).to_have_count(2)
 
 
-@pytest.mark.parametrize("marimo_server", ["demos/sortlist.py"], indirect=True)
-def test_edit_item_updates_value(marimo_server: str, page: Page):
+def test_edit_item_updates_value(start_marimo, page: Page):
     """Test that editing an item updates its value."""
-    page.goto(marimo_server, wait_until="networkidle")
+    url = start_marimo("demos/sortlist.py")
+    page.goto(url, wait_until="networkidle")
 
     widget = page.locator(".draggable-list-widget")
-    expect(widget).to_be_visible(timeout=WIDGET_TIMEOUT)
+    expect(widget).to_be_visible()
 
     first_label = page.locator(".item-label").first
     first_label.click()
@@ -81,13 +74,13 @@ def test_edit_item_updates_value(marimo_server: str, page: Page):
     expect(edited_label).to_be_visible()
 
 
-@pytest.mark.parametrize("marimo_server", ["demos/sortlist.py"], indirect=True)
-def test_python_state_updates_after_add(marimo_server: str, page: Page):
+def test_python_state_updates_after_add(start_marimo, page: Page):
     """Test that adding an item updates the Python state visible in the notebook."""
-    page.goto(marimo_server, wait_until="networkidle")
+    url = start_marimo("demos/sortlist.py")
+    page.goto(url, wait_until="networkidle")
 
     widget = page.locator(".draggable-list-widget")
-    expect(widget).to_be_visible(timeout=WIDGET_TIMEOUT)
+    expect(widget).to_be_visible()
 
     add_input = page.locator(".add-input")
     add_input.fill("python_test")
@@ -96,4 +89,4 @@ def test_python_state_updates_after_add(marimo_server: str, page: Page):
     page.wait_for_timeout(500)
 
     # The Python output cell should show the new value
-    page.wait_for_selector("text=python_test", timeout=WIDGET_TIMEOUT)
+    page.wait_for_selector("text=python_test")


### PR DESCRIPTION
Replace pytest.mark.parametrize with indirect=True with a simple fixture factory. Tests now read top-to-bottom with obvious intent: url = start_marimo("demos/sortlist.py") says exactly what's happening, no pytest docs needed.

Also removed WIDGET_TIMEOUT in favor of Playwright defaults, and updated CLAUDE.md to document the "dumber is better" principle for code readability.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>