### PR TITLE
Make gallery images clickable links to demo pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,38 +14,38 @@ uv pip install wigglystuff
 
 <table>
 <tr>
-<td align="center"><b>Slider2D</b><br><img src="./mkdocs/assets/gallery/slider2d.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/slider2d/">Demo</a> · <a href="./wigglystuff/slider2d.py">Source</a></td>
-<td align="center"><b>Matrix</b><br><img src="./mkdocs/assets/gallery/matrix.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/matrix/">Demo</a> · <a href="./wigglystuff/matrix.py">Source</a></td>
-<td align="center"><b>Paint</b><br><img src="./mkdocs/assets/gallery/paint.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/paint/">Demo</a> · <a href="./wigglystuff/paint.py">Source</a></td>
+<td align="center"><b>Slider2D</b><br><a href="https://koaning.github.io/wigglystuff/examples/slider2d/"><img src="./mkdocs/assets/gallery/slider2d.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/slider2d/">Demo</a> · <a href="./wigglystuff/slider2d.py">Source</a></td>
+<td align="center"><b>Matrix</b><br><a href="https://koaning.github.io/wigglystuff/examples/matrix/"><img src="./mkdocs/assets/gallery/matrix.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/matrix/">Demo</a> · <a href="./wigglystuff/matrix.py">Source</a></td>
+<td align="center"><b>Paint</b><br><a href="https://koaning.github.io/wigglystuff/examples/paint/"><img src="./mkdocs/assets/gallery/paint.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/paint/">Demo</a> · <a href="./wigglystuff/paint.py">Source</a></td>
 </tr>
 <tr>
-<td align="center"><b>EdgeDraw</b><br><img src="./mkdocs/assets/gallery/edgedraw.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/edgedraw/">Demo</a> · <a href="./wigglystuff/edge_draw.py">Source</a></td>
-<td align="center"><b>SortableList</b><br><img src="./mkdocs/assets/gallery/sortablelist.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/sortlist/">Demo</a> · <a href="./wigglystuff/sortable_list.py">Source</a></td>
-<td align="center"><b>ColorPicker</b><br><img src="./mkdocs/assets/gallery/colorpicker.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/colorpicker/">Demo</a> · <a href="./wigglystuff/color_picker.py">Source</a></td>
+<td align="center"><b>EdgeDraw</b><br><a href="https://koaning.github.io/wigglystuff/examples/edgedraw/"><img src="./mkdocs/assets/gallery/edgedraw.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/edgedraw/">Demo</a> · <a href="./wigglystuff/edge_draw.py">Source</a></td>
+<td align="center"><b>SortableList</b><br><a href="https://koaning.github.io/wigglystuff/examples/sortlist/"><img src="./mkdocs/assets/gallery/sortablelist.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/sortlist/">Demo</a> · <a href="./wigglystuff/sortable_list.py">Source</a></td>
+<td align="center"><b>ColorPicker</b><br><a href="https://koaning.github.io/wigglystuff/examples/colorpicker/"><img src="./mkdocs/assets/gallery/colorpicker.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/colorpicker/">Demo</a> · <a href="./wigglystuff/color_picker.py">Source</a></td>
 </tr>
 <tr>
-<td align="center"><b>GamepadWidget</b><br><img src="./mkdocs/assets/gallery/gamepad.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/gamepad/">Demo</a> · <a href="./wigglystuff/gamepad.py">Source</a></td>
-<td align="center"><b>KeystrokeWidget</b><br><img src="./mkdocs/assets/gallery/keystroke.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/keystroke/">Demo</a> · <a href="./wigglystuff/keystroke.py">Source</a></td>
-<td align="center"><b>SpeechToText</b><br><img src="./mkdocs/assets/gallery/speechtotext.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/talk/">Demo</a> · <a href="./wigglystuff/talk.py">Source</a></td>
+<td align="center"><b>GamepadWidget</b><br><a href="https://koaning.github.io/wigglystuff/examples/gamepad/"><img src="./mkdocs/assets/gallery/gamepad.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/gamepad/">Demo</a> · <a href="./wigglystuff/gamepad.py">Source</a></td>
+<td align="center"><b>KeystrokeWidget</b><br><a href="https://koaning.github.io/wigglystuff/examples/keystroke/"><img src="./mkdocs/assets/gallery/keystroke.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/keystroke/">Demo</a> · <a href="./wigglystuff/keystroke.py">Source</a></td>
+<td align="center"><b>SpeechToText</b><br><a href="https://koaning.github.io/wigglystuff/examples/talk/"><img src="./mkdocs/assets/gallery/speechtotext.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/talk/">Demo</a> · <a href="./wigglystuff/talk.py">Source</a></td>
 </tr>
 <tr>
-<td align="center"><b>CopyToClipboard</b><br><img src="./mkdocs/assets/gallery/copytoclipboard.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/copytoclipboard/">Demo</a> · <a href="./wigglystuff/copy_to_clipboard.py">Source</a></td>
-<td align="center"><b>CellTour</b><br><img src="./mkdocs/assets/gallery/celltour.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/celltour/">Demo</a> · <a href="./wigglystuff/cell_tour.py">Source</a></td>
-<td align="center"><b>WebcamCapture</b><br><img src="./mkdocs/assets/gallery/webcam-capture.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/webcam_capture/">Demo</a> · <a href="./wigglystuff/webcam_capture.py">Source</a></td>
+<td align="center"><b>CopyToClipboard</b><br><a href="https://koaning.github.io/wigglystuff/examples/copytoclipboard/"><img src="./mkdocs/assets/gallery/copytoclipboard.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/copytoclipboard/">Demo</a> · <a href="./wigglystuff/copy_to_clipboard.py">Source</a></td>
+<td align="center"><b>CellTour</b><br><a href="https://koaning.github.io/wigglystuff/examples/celltour/"><img src="./mkdocs/assets/gallery/celltour.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/celltour/">Demo</a> · <a href="./wigglystuff/cell_tour.py">Source</a></td>
+<td align="center"><b>WebcamCapture</b><br><a href="https://koaning.github.io/wigglystuff/examples/webcam_capture/"><img src="./mkdocs/assets/gallery/webcam-capture.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/webcam_capture/">Demo</a> · <a href="./wigglystuff/webcam_capture.py">Source</a></td>
 </tr>
 <tr>
-<td align="center"><b>ThreeWidget</b><br><img src="./mkdocs/assets/gallery/threewidget.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/threewidget/">Demo</a> · <a href="./wigglystuff/three_widget.py">Source</a></td>
-<td align="center"><b>ImageRefreshWidget</b><br><img src="./mkdocs/assets/gallery/imagerefresh.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/html/">Demo</a> · <a href="./wigglystuff/html.py">Source</a></td>
-<td align="center"><b>HTMLRefreshWidget</b><br><img src="./mkdocs/assets/gallery/htmlwidget.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/html/">Demo</a> · <a href="./wigglystuff/html.py">Source</a></td>
+<td align="center"><b>ThreeWidget</b><br><a href="https://koaning.github.io/wigglystuff/examples/threewidget/"><img src="./mkdocs/assets/gallery/threewidget.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/threewidget/">Demo</a> · <a href="./wigglystuff/three_widget.py">Source</a></td>
+<td align="center"><b>ImageRefreshWidget</b><br><a href="https://koaning.github.io/wigglystuff/examples/html/"><img src="./mkdocs/assets/gallery/imagerefresh.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/html/">Demo</a> · <a href="./wigglystuff/html.py">Source</a></td>
+<td align="center"><b>HTMLRefreshWidget</b><br><a href="https://koaning.github.io/wigglystuff/examples/html/"><img src="./mkdocs/assets/gallery/htmlwidget.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/html/">Demo</a> · <a href="./wigglystuff/html.py">Source</a></td>
 </tr>
 <tr>
-<td align="center"><b>ProgressBar</b><br><img src="./mkdocs/assets/gallery/progressbar.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/html/">Demo</a> · <a href="./wigglystuff/html.py">Source</a></td>
-<td align="center"><b>PulsarChart</b><br><img src="./mkdocs/assets/gallery/pulsarchart.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/pulsarchart/">Demo</a> · <a href="./wigglystuff/pulsar_chart.py">Source</a></td>
-<td align="center"><b>TextCompare</b><br><img src="./mkdocs/assets/gallery/textcompare.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/textcompare/">Demo</a> · <a href="./wigglystuff/text_compare.py">Source</a></td>
+<td align="center"><b>ProgressBar</b><br><a href="https://koaning.github.io/wigglystuff/examples/html/"><img src="./mkdocs/assets/gallery/progressbar.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/html/">Demo</a> · <a href="./wigglystuff/html.py">Source</a></td>
+<td align="center"><b>PulsarChart</b><br><a href="https://koaning.github.io/wigglystuff/examples/pulsarchart/"><img src="./mkdocs/assets/gallery/pulsarchart.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/pulsarchart/">Demo</a> · <a href="./wigglystuff/pulsar_chart.py">Source</a></td>
+<td align="center"><b>TextCompare</b><br><a href="https://koaning.github.io/wigglystuff/examples/textcompare/"><img src="./mkdocs/assets/gallery/textcompare.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/textcompare/">Demo</a> · <a href="./wigglystuff/text_compare.py">Source</a></td>
 </tr>
 <tr>
-<td align="center"><b>EnvConfig</b><br><img src="./mkdocs/assets/gallery/envconfig.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/envconfig/">Demo</a> · <a href="./wigglystuff/env_config.py">Source</a></td>
-<td align="center"><b>Tangle</b><br><img src="./mkdocs/assets/gallery/tangle.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/tangle/">Demo</a> · <a href="./wigglystuff/tangle.py">Source</a></td>
-<td align="center"><b>ChartPuck</b><br><img src="./mkdocs/assets/gallery/chartpuck.png" width="200"><br><a href="https://koaning.github.io/wigglystuff/examples/chartpuck/">Demo</a> · <a href="./wigglystuff/chart_puck.py">Source</a></td>
+<td align="center"><b>EnvConfig</b><br><a href="https://koaning.github.io/wigglystuff/examples/envconfig/"><img src="./mkdocs/assets/gallery/envconfig.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/envconfig/">Demo</a> · <a href="./wigglystuff/env_config.py">Source</a></td>
+<td align="center"><b>Tangle</b><br><a href="https://koaning.github.io/wigglystuff/examples/tangle/"><img src="./mkdocs/assets/gallery/tangle.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/tangle/">Demo</a> · <a href="./wigglystuff/tangle.py">Source</a></td>
+<td align="center"><b>ChartPuck</b><br><a href="https://koaning.github.io/wigglystuff/examples/chartpuck/"><img src="./mkdocs/assets/gallery/chartpuck.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/chartpuck/">Demo</a> · <a href="./wigglystuff/chart_puck.py">Source</a></td>
 </tr>
 </table>


### PR DESCRIPTION
Wrap each widget gallery image in the README with an anchor tag linking to its corresponding demo page. This allows users to click directly on images to access the demos instead of only using the Demo text links.

All 19 gallery images are now interactive links to their respective demo pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)