### PR TITLE
Remove scikit-learn from core dependencies (v0.2.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.18] - 2026-01-26
+
+### Fixed
+- Removed `scikit-learn` from core dependencies. It was accidentally added as a required dependency but is only used by the optional `ChartPuck.export_kmeans()` method. Users of this method should install with `pip install wigglystuff[test]`.
+
 ## [0.2.17] - 2026-01-26
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.17"
+version = "0.2.18"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -17,7 +17,6 @@ dependencies = [
     "anywidget>=0.9.2",
     "numpy",
     "pillow",
-    "scikit-learn>=1.7.2",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3458,15 +3458,13 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.17"
+version = "0.2.18"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -3520,7 +3518,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3" },
     { name = "pytest", marker = "extra == 'test-browser'", specifier = ">=8.3.3" },
     { name = "pytest-playwright", marker = "extra == 'test-browser'", specifier = ">=0.6.2" },
-    { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "scikit-learn", marker = "extra == 'test'", specifier = ">=1.0" },
 ]
 provides-extras = ["test", "test-browser", "docs"]


### PR DESCRIPTION
## Summary
Removed scikit-learn from core dependencies since it's only used by the optional `ChartPuck.export_kmeans()` method with a lazy import. Bumped version to 0.2.18 and added changelog entry.

## Changes
- Remove `scikit-learn>=1.7.2` from pyproject.toml dependencies
- Update version to 0.2.18
- Update uv.lock

Users needing scikit-learn can install with `pip install wigglystuff[test]`.

🤖 Generated with Claude Code