### PR TITLE
EnvConfig: add get() and optional require_valid() filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.20] - 2026-02-02
+
+### Added
+- `EnvConfig.get(name, default=None)` method for dict-like access that returns a default value instead of raising `KeyError`.
+- Optional `variables` parameter to `EnvConfig.require_valid()` to check only a subset of configured variables, allowing some to remain unset.
+
 ## [0.2.19] - 2026-01-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.19"
+version = "0.2.20"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -3458,7 +3458,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.19"
+version = "0.2.20"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/env_config.py
+++ b/wigglystuff/env_config.py
@@ -149,19 +149,36 @@ class EnvConfig(anywidget.AnyWidget):
         """Recalculate all_valid based on current variable statuses."""
         self.all_valid = all(v["status"] == "valid" for v in self.variables)
 
-    def require_valid(self) -> None:
-        """Assert all environment variables are valid.
+    def require_valid(self, variables: Optional[Sequence[str]] = None) -> None:
+        """Assert environment variables are valid.
+
+        Args:
+            variables: Optional list of variable names to check. If None,
+                checks all configured variables.
 
         Raises:
-            EnvironmentError: If any variable is missing or invalid.
+            EnvironmentError: If any checked variable is missing or invalid.
+            ValueError: If a variable name is not configured in this widget.
         """
-        if self.all_valid:
+        configured = {v["name"] for v in self.variables}
+        to_check = configured if variables is None else set(variables)
+        unknown = to_check - configured
+        if unknown:
+            raise ValueError(
+                f"Variable(s) not configured in this EnvConfig: {', '.join(sorted(unknown))}"
+            )
+
+        # Filter to only checked variables
+        checked_vars = [v for v in self.variables if v["name"] in to_check]
+
+        # Early return if all checked vars are valid
+        if all(v["status"] == "valid" for v in checked_vars):
             return
 
-        missing = [v["name"] for v in self.variables if v["status"] == "missing"]
+        missing = [v["name"] for v in checked_vars if v["status"] == "missing"]
         invalid = [
             f"{v['name']} ({v['error']})"
-            for v in self.variables
+            for v in checked_vars
             if v["status"] == "invalid"
         ]
 
@@ -192,6 +209,20 @@ class EnvConfig(anywidget.AnyWidget):
             raise KeyError(f"{name!r} is not configured in this EnvConfig")
         if name not in self._values:
             raise KeyError(f"{name!r} is not set")
+        return self._values[name]
+
+    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        """Get variable value by name, with optional default.
+
+        Args:
+            name: The variable name.
+            default: Value to return if variable is not configured or not set.
+
+        Returns:
+            The value if set, otherwise the default.
+        """
+        if name not in self._var_names or name not in self._values:
+            return default
         return self._values[name]
 
     def __contains__(self, name: str) -> bool:


### PR DESCRIPTION
## Summary

- Add `EnvConfig.get(name, default=None)` method for dict-like access that returns a default instead of raising KeyError
- Add optional `variables` parameter to `EnvConfig.require_valid()` to check only a subset of configured variables, allowing some to remain unset
- Bump version to 0.2.20

## Test plan

- All 24 existing tests pass
- 7 new tests covering subset validation and get() method with various scenarios