### PR TITLE
ColorPicker hex label and sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.21] - 2026-02-04
 
+### Added
+- ColorPicker now shows the hex value next to the input by default (toggle with `show_label`).
+
 ### Fixed
 - ColorPicker now keeps its hex label in sync when the color is updated programmatically (e.g., demo button updates).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.21] - 2026-02-04
+
+### Fixed
+- ColorPicker now keeps its hex label in sync when the color is updated programmatically (e.g., demo button updates).
+
 ## [0.2.20] - 2026-02-02
 
 ### Added

--- a/demos/colorpicker.py
+++ b/demos/colorpicker.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "marimo>=0.19.7",
+#     "wigglystuff==0.2.21",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.18.2"
@@ -30,6 +37,7 @@ def _(mo, picker):
                 f"<div style='width:96px;height:96px;border-radius:0.75rem;"
                 f"border:1px solid #d4d4d8;background:{picker.color};'></div>"
             ),
+            mo.md("Hex labels are shown by default. Set `show_label=False` to hide them."),
         ]
     )
     return
@@ -45,11 +53,6 @@ def _(mo, picker):
 
 
     mo.ui.button(label="Surprise me", on_click=randomize)
-    return
-
-
-@app.cell
-def _():
     return
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.20"
+version = "0.2.21"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -3458,7 +3458,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.20"
+version = "0.2.21"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/color_picker.py
+++ b/wigglystuff/color_picker.py
@@ -16,17 +16,28 @@ class ColorPicker(anywidget.AnyWidget):
     """
 
     _esm = Path(__file__).parent / "static" / "colorpicker.js"
+    _css = Path(__file__).parent / "static" / "colorpicker.css"
     color = traitlets.Unicode("#000000").tag(sync=True)
+    show_label = traitlets.Bool(True).tag(sync=True)
 
-    def __init__(self, *, color: Optional[str] = None, **kwargs: Any):
+    def __init__(
+        self,
+        *,
+        color: Optional[str] = None,
+        show_label: Optional[bool] = None,
+        **kwargs: Any,
+    ):
         """Create a ColorPicker widget.
 
         Args:
             color: Optional starting hex color (e.g. ``"#ff00aa"``).
+            show_label: Whether to show the hex label next to the picker.
             **kwargs: Forwarded to ``anywidget.AnyWidget``.
         """
         if color is not None:
             kwargs["color"] = color
+        if show_label is not None:
+            kwargs["show_label"] = show_label
         super().__init__(**kwargs)
 
     @property

--- a/wigglystuff/color_picker.py
+++ b/wigglystuff/color_picker.py
@@ -24,7 +24,7 @@ class ColorPicker(anywidget.AnyWidget):
         self,
         *,
         color: Optional[str] = None,
-        show_label: Optional[bool] = None,
+        show_label: bool = True,
         **kwargs: Any,
     ):
         """Create a ColorPicker widget.
@@ -34,11 +34,9 @@ class ColorPicker(anywidget.AnyWidget):
             show_label: Whether to show the hex label next to the picker.
             **kwargs: Forwarded to ``anywidget.AnyWidget``.
         """
-        if color is not None:
-            kwargs["color"] = color
-        if show_label is not None:
-            kwargs["show_label"] = show_label
-        super().__init__(**kwargs)
+        if color is None:
+            color = "#000000"
+        super().__init__(color=color, show_label=show_label, **kwargs)
 
     @property
     def rgb(self):

--- a/wigglystuff/static/colorpicker.css
+++ b/wigglystuff/static/colorpicker.css
@@ -1,0 +1,33 @@
+.colorpicker-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  color-scheme: light dark;
+  position: relative;
+
+  --colorpicker-border: #d1d5db;
+  --colorpicker-label-bg: #f3f4f6;
+  --colorpicker-label-text: #111827;
+}
+
+.colorpicker-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--colorpicker-border);
+  background: var(--colorpicker-label-bg);
+  color: var(--colorpicker-label-text);
+  user-select: none;
+}
+
+.dark .colorpicker-wrapper,
+.dark-theme .colorpicker-wrapper,
+[data-theme="dark"] .colorpicker-wrapper {
+  --colorpicker-border: #475569;
+  --colorpicker-label-bg: #1f2937;
+  --colorpicker-label-text: #e2e8f0;
+}

--- a/wigglystuff/static/colorpicker.js
+++ b/wigglystuff/static/colorpicker.js
@@ -1,18 +1,46 @@
-function render({model, el}) {
-  const ip = document.createElement('input');
-  ip.type = 'color';
-  ip.value = model.get('color');
+function render({ model, el }) {
+  el.innerHTML = '';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'colorpicker-wrapper';
 
-  ip.addEventListener('input', () => {
-    model.set('color', ip.value);
+  const input = document.createElement('input');
+  input.type = 'color';
+  input.className = 'colorpicker-input';
+  input.value = model.get('color');
+
+  const label = document.createElement('span');
+  label.className = 'colorpicker-label';
+
+  let localUpdate = false;
+
+  const syncFromModel = () => {
+    const color = model.get('color') || '#000000';
+    input.value = color;
+    label.textContent = color;
+    const showLabel = model.get('show_label');
+    label.style.display = showLabel === false ? 'none' : '';
+
+    if (!localUpdate) {
+      // Echo backend-driven updates so marimo can react to programmatic changes.
+      model.save_changes();
+    }
+    localUpdate = false;
+  };
+
+  input.addEventListener('input', () => {
+    localUpdate = true;
+    model.set('color', input.value);
     model.save_changes();
   });
 
-  model.on('change:color', () => {
-    ip.value = model.get('color');
-  });
+  model.on('change:color', syncFromModel);
+  model.on('change:show_label', syncFromModel);
 
-  el.appendChild(ip);
+  wrapper.appendChild(input);
+  wrapper.appendChild(label);
+  el.appendChild(wrapper);
+
+  syncFromModel();
 }
 
 export default { render };


### PR DESCRIPTION
Adds a hex label next to ColorPicker (toggle via show_label) and syncs programmatic color updates so dependent cells refresh. Bumps version to 0.2.21 and updates the demo + changelog. Tested with .