### PR TITLE
Add per-puck colors and throttle to ChartPuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.22] - 2026-02-08
+
+### Added
+- `ChartPuck.puck_color` now accepts a list of CSS colors for per-puck coloring (e.g., `puck_color=["red", "green", "blue"]`). A single string still applies to all pucks.
+- New `throttle` parameter on `ChartPuck` to control how often puck positions sync to Python during drag. Set to an integer for millisecond throttling (e.g., `throttle=100`) or `"dragend"` to sync only on release.
+
+### Changed
+- Removed `**kwargs` from `ChartPuck.__init__`; all parameters are now explicit.
+
 ## [0.2.21] - 2026-02-04
 
 ### Added

--- a/agents.md
+++ b/agents.md
@@ -10,7 +10,7 @@ syncs back to Python.
 | Agent | Module/Class | Core traitlets | One-liner |
 | --- | --- | --- | --- |
 | Slider2D | `wigglystuff.slider2d.Slider2D` | `x`, `y`, `x_bounds`, `y_bounds`, `width`, `height` | 2D pointer for coupled parameters |
-| ChartPuck | `wigglystuff.chart_puck.ChartPuck` | `x`, `y`, `x_bounds`, `y_bounds`, `axes_pixel_bounds`, `width`, `height`, `chart_base64`, `puck_radius`, `puck_color` | Draggable puck overlay for matplotlib charts |
+| ChartPuck | `wigglystuff.chart_puck.ChartPuck` | `x`, `y`, `x_bounds`, `y_bounds`, `axes_pixel_bounds`, `width`, `height`, `chart_base64`, `puck_radius`, `puck_color`, `throttle` | Draggable puck overlay for matplotlib charts |
 | ChartSelect | `wigglystuff.chart_select.ChartSelect` | `mode`, `selection`, `has_selection`, `x_bounds`, `y_bounds`, `axes_pixel_bounds`, `width`, `height`, `chart_base64`, `selection_color`, `selection_opacity` | Box/lasso selection on matplotlib charts |
 | Matrix | `wigglystuff.matrix.Matrix` | `matrix`, `rows`, `cols`, `min_value`, `max_value`, `step`, `mirror` | Spreadsheet-like numeric editor |
 | TangleSlider | `wigglystuff.tangle.TangleSlider` | `amount`, `min_value`, `max_value`, `step`, `pixels_per_step` | Inline slider ala Bret Victor |

--- a/demos/chartpuck.py
+++ b/demos/chartpuck.py
@@ -52,7 +52,7 @@ def _(ChartPuck, np, plt):
 
     puck = ChartPuck(fig, x=0, y=0)
     plt.close(fig)
-    return fig, puck
+    return (puck,)
 
 
 @app.cell
@@ -70,12 +70,6 @@ def _(widget):
 @app.cell
 def _(mo, widget):
     mo.callout(f"Selected position: x = {widget.x[0]:.3f}, y = {widget.y[0]:.3f}")
-    return
-
-
-@app.cell
-def _(ChartPuck, fig):
-    ChartPuck(fig, x=[1, 2, 3], y=[1, 2, 3], puck_color=["red", "green", "blue"], puck_radius=5)
     return
 
 
@@ -107,7 +101,7 @@ def _(ChartPuck, np, plt):
         fig2,
         x=[-1.5, 0, 1.5],
         y=[-1.5, 0, 1.5],
-        puck_color="#2196f3",
+        puck_color=["green", "red", "blue"],
     )
     plt.close(fig2)
     return (multi_puck,)
@@ -161,6 +155,7 @@ def _(ChartPuck, dynamic_data_x, dynamic_data_y):
         ax.set_title(f"Position: ({x:.2f}, {y:.2f})")
         ax.grid(True, alpha=0.3)
 
+    # ChartPuck(fig, x=[1, 2, 3], y=[1, 2, 3], puck_color=["red", "green", "blue"], puck_radius=5, throttle=100)
 
     dynamic_puck = ChartPuck.from_callback(
         draw_fn=draw_with_crosshairs,
@@ -170,6 +165,7 @@ def _(ChartPuck, dynamic_data_x, dynamic_data_y):
         x=0,
         y=0,
         puck_color="#4caf50",
+        throttle=100
     )
     return (dynamic_puck,)
 

--- a/demos/chartpuck.py
+++ b/demos/chartpuck.py
@@ -12,7 +12,7 @@
 
 import marimo
 
-__generated_with = "0.19.6"
+__generated_with = "0.19.9"
 app = marimo.App()
 
 
@@ -22,6 +22,7 @@ def _():
     import matplotlib.pyplot as plt
     import numpy as np
     from wigglystuff import ChartPuck
+
     return ChartPuck, mo, np, plt
 
 
@@ -51,7 +52,7 @@ def _(ChartPuck, np, plt):
 
     puck = ChartPuck(fig, x=0, y=0)
     plt.close(fig)
-    return (puck,)
+    return fig, puck
 
 
 @app.cell
@@ -69,6 +70,12 @@ def _(widget):
 @app.cell
 def _(mo, widget):
     mo.callout(f"Selected position: x = {widget.x[0]:.3f}, y = {widget.y[0]:.3f}")
+    return
+
+
+@app.cell
+def _(ChartPuck, fig):
+    ChartPuck(fig, x=[1, 2, 3], y=[1, 2, 3], puck_color=["red", "green", "blue"], puck_radius=5)
     return
 
 

--- a/mkdocs/reference/chart-puck.md
+++ b/mkdocs/reference/chart-puck.md
@@ -16,3 +16,4 @@
 | `chart_base64` | `str` | Base64-encoded PNG of the matplotlib figure. |
 | `puck_radius` | `int` | Radius of puck(s) in pixels. |
 | `puck_color` | `str \| list[str]` | CSS color(s) of puck(s). A single color applies to all; a list assigns one per puck. |
+| `throttle` | `int \| str` | Drag sync rate. `0` = every move, int = ms throttle, `"dragend"` = on release. |

--- a/mkdocs/reference/chart-puck.md
+++ b/mkdocs/reference/chart-puck.md
@@ -15,4 +15,4 @@
 | `height` | `int` | Canvas height in pixels. |
 | `chart_base64` | `str` | Base64-encoded PNG of the matplotlib figure. |
 | `puck_radius` | `int` | Radius of puck(s) in pixels. |
-| `puck_color` | `str` | CSS color of puck(s). |
+| `puck_color` | `str \| list[str]` | CSS color(s) of puck(s). A single color applies to all; a list assigns one per puck. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.21"
+version = "0.2.22"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_chart_puck.py
+++ b/tests/test_chart_puck.py
@@ -68,6 +68,21 @@ def test_from_callback_creates_widget_and_updates():
     assert puck.chart_base64 != initial_base64
 
 
+def test_chart_puck_single_color_string(simple_figure):
+    puck = ChartPuck(simple_figure, puck_color="blue")
+    assert puck.puck_color == ["blue"]
+
+
+def test_chart_puck_color_list(simple_figure):
+    puck = ChartPuck(
+        simple_figure,
+        x=[1.0, 2.0, 3.0],
+        y=[1.0, 2.0, 3.0],
+        puck_color=["red", "green", "blue"],
+    )
+    assert puck.puck_color == ["red", "green", "blue"]
+
+
 def test_export_kmeans(simple_figure):
     sklearn = pytest.importorskip("sklearn")
     puck = ChartPuck(simple_figure, x=[1.0, 3.0], y=[1.0, 3.0])

--- a/tests/test_chart_puck.py
+++ b/tests/test_chart_puck.py
@@ -83,6 +83,21 @@ def test_chart_puck_color_list(simple_figure):
     assert puck.puck_color == ["red", "green", "blue"]
 
 
+def test_chart_puck_throttle_default(simple_figure):
+    puck = ChartPuck(simple_figure)
+    assert puck.throttle == 0
+
+
+def test_chart_puck_throttle_ms(simple_figure):
+    puck = ChartPuck(simple_figure, throttle=100)
+    assert puck.throttle == 100
+
+
+def test_chart_puck_throttle_dragend(simple_figure):
+    puck = ChartPuck(simple_figure, throttle="dragend")
+    assert puck.throttle == "dragend"
+
+
 def test_export_kmeans(simple_figure):
     sklearn = pytest.importorskip("sklearn")
     puck = ChartPuck(simple_figure, x=[1.0, 3.0], y=[1.0, 3.0])

--- a/uv.lock
+++ b/uv.lock
@@ -3458,7 +3458,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.21"
+version = "0.2.22"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/chart_puck.py
+++ b/wigglystuff/chart_puck.py
@@ -104,6 +104,12 @@ class ChartPuck(anywidget.AnyWidget):
     puck_radius = traitlets.Int(10).tag(sync=True)
     puck_color = traitlets.List(traitlets.Unicode(), default_value=["#e63946"]).tag(sync=True)
 
+    # Drag throttling: 0 = every move, int = ms throttle, "dragend" = on release
+    throttle = traitlets.Union(
+        [traitlets.Int(), traitlets.Unicode()],
+        default_value=0,
+    ).tag(sync=True)
+
     # Optional drag constraints (if None, uses chart bounds)
     drag_x_bounds = traitlets.Union(
         [traitlets.Tuple(traitlets.Float(), traitlets.Float()), traitlets.Instance(type(None))],
@@ -123,6 +129,7 @@ class ChartPuck(anywidget.AnyWidget):
         y: float | list[float] | None = None,
         puck_radius: int = 10,
         puck_color: str | list[str] = "#e63946",
+        throttle: int | str = 0,
         drag_x_bounds: tuple[float, float] | None = None,
         drag_y_bounds: tuple[float, float] | None = None,
     ) -> None:
@@ -138,6 +145,10 @@ class ChartPuck(anywidget.AnyWidget):
             puck_color: Color of the puck(s). A single CSS color string applies
                 to all pucks. A list of CSS colors assigns one color per puck
                 (cycled if shorter than the number of pucks).
+            throttle: Controls how often puck position syncs to Python during
+                drag. ``0`` syncs on every mouse move (default). An integer
+                syncs at most once every N milliseconds. ``"dragend"`` syncs
+                only when the user releases the puck.
             drag_x_bounds: Optional (min, max) to constrain puck dragging on x-axis.
                           If None, uses the chart's x_bounds.
             drag_y_bounds: Optional (min, max) to constrain puck dragging on y-axis.
@@ -183,6 +194,7 @@ class ChartPuck(anywidget.AnyWidget):
             chart_base64=chart_base64,
             puck_radius=puck_radius,
             puck_color=puck_color,
+            throttle=throttle,
             drag_x_bounds=drag_x_bounds,
             drag_y_bounds=drag_y_bounds,
         )

--- a/wigglystuff/chart_puck.py
+++ b/wigglystuff/chart_puck.py
@@ -102,7 +102,7 @@ class ChartPuck(anywidget.AnyWidget):
 
     # Puck styling
     puck_radius = traitlets.Int(10).tag(sync=True)
-    puck_color = traitlets.Unicode("#e63946").tag(sync=True)
+    puck_color = traitlets.List(traitlets.Unicode(), default_value=["#e63946"]).tag(sync=True)
 
     # Optional drag constraints (if None, uses chart bounds)
     drag_x_bounds = traitlets.Union(
@@ -122,10 +122,9 @@ class ChartPuck(anywidget.AnyWidget):
         x: float | list[float] | None = None,
         y: float | list[float] | None = None,
         puck_radius: int = 10,
-        puck_color: str = "#e63946",
+        puck_color: str | list[str] = "#e63946",
         drag_x_bounds: tuple[float, float] | None = None,
         drag_y_bounds: tuple[float, float] | None = None,
-        **kwargs: Any,
     ) -> None:
         """Create a ChartPuck widget from a matplotlib figure.
 
@@ -136,12 +135,13 @@ class ChartPuck(anywidget.AnyWidget):
             y: Initial y coordinate(s) in data space. Can be a single value or
                a list for multiple pucks. Defaults to center of y_bounds.
             puck_radius: Radius of the puck(s) in pixels.
-            puck_color: Color of the puck(s) (any CSS color).
+            puck_color: Color of the puck(s). A single CSS color string applies
+                to all pucks. A list of CSS colors assigns one color per puck
+                (cycled if shorter than the number of pucks).
             drag_x_bounds: Optional (min, max) to constrain puck dragging on x-axis.
                           If None, uses the chart's x_bounds.
             drag_y_bounds: Optional (min, max) to constrain puck dragging on y-axis.
                           If None, uses the chart's y_bounds.
-            **kwargs: Forwarded to ``anywidget.AnyWidget``.
         """
         x_bounds, y_bounds, axes_pixel_bounds, width_px, height_px = extract_axes_info(
             fig
@@ -168,6 +168,10 @@ class ChartPuck(anywidget.AnyWidget):
                 f"x and y must have the same length, got {len(x)} and {len(y)}"
             )
 
+        # Normalize puck_color to list
+        if isinstance(puck_color, str):
+            puck_color = [puck_color]
+
         super().__init__(
             x=x,
             y=y,
@@ -181,7 +185,6 @@ class ChartPuck(anywidget.AnyWidget):
             puck_color=puck_color,
             drag_x_bounds=drag_x_bounds,
             drag_y_bounds=drag_y_bounds,
-            **kwargs,
         )
 
     @classmethod

--- a/wigglystuff/static/chart-puck.js
+++ b/wigglystuff/static/chart-puck.js
@@ -84,11 +84,11 @@ function render({ model, el }) {
     const xs = model.get("x");
     const ys = model.get("y");
     const radius = model.get("puck_radius");
-    const color = model.get("puck_color");
+    const colors = model.get("puck_color");
 
     for (let i = 0; i < xs.length; i++) {
       const puckPos = dataToPixel(xs[i], ys[i]);
-      drawPuck(puckPos.x, puckPos.y, radius, color);
+      drawPuck(puckPos.x, puckPos.y, radius, colors[i % colors.length]);
     }
   }
 


### PR DESCRIPTION
## Summary
- `puck_color` now accepts a list of CSS colors for per-puck coloring (e.g., `puck_color=["red", "green", "blue"]`). A single string still applies to all pucks.
- New `throttle` parameter to control how often puck positions sync to Python during drag. Set to an integer for ms throttling (e.g., `throttle=100`) or `"dragend"` to sync only on release.
- Removed `**kwargs` from `ChartPuck.__init__`; all parameters are now explicit.
- Version bump to 0.2.22.