### PR TITLE
Add GitHub issue template requiring marimo reproducible notebook

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,12 @@
+---
+name: Bug Report
+about: Report a bug in wigglystuff
+labels: bug
+---
+
+Please describe the bug and include a **marimo notebook** that reproduces it.
+Without a reproducible notebook it is very hard to diagnose what is going on,
+so issues without one may be closed.
+
+You can paste the notebook source directly, link to a GitHub Gist, or share
+a [marimo.app](https://marimo.app) link — whatever is easiest.


### PR DESCRIPTION
Add a simple markdown template that guides users to provide a marimo notebook when reporting bugs. Users can paste the notebook source directly, share a GitHub Gist, or link to a marimo.app notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)