### PR TITLE
Add WandbChart reference docs and fix stray URL

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -31,6 +31,7 @@ syncs back to Python.
 | TextCompare | `wigglystuff.text_compare.TextCompare` | `text_a`, `text_b`, `matches`, `selected_match`, `min_match_words` | Side-by-side text diff with match highlighting |
 | EnvConfig | `wigglystuff.env_config.EnvConfig` | `variables`, `all_valid` | Environment variable config with validation |
 | ModuleTreeWidget | `wigglystuff.module_tree.ModuleTreeWidget` | `tree`, `initial_expand_depth` | Interactive tree viewer for PyTorch nn.Module |
+| WandbChart | `wigglystuff.wandb_chart.WandbChart` | `api_key`, `entity`, `project`, `key`, `poll_seconds`, `smoothing_kind`, `smoothing_param`, `show_slider`, `width`, `height` | Live line chart that polls wandb for metric data with smoothing |
 | Neo4jWidget | `wigglystuff.neo4j_widget.Neo4jWidget` | `nodes`, `relationships`, `schema`, `error`, `query_running`, `selected_nodes`, `selected_relationships`, `width`, `height` | Interactive Neo4j graph explorer with Cypher query input |
 | ScatterWidget | `wigglystuff.scatter_widget.ScatterWidget` | `data`, `brushsize`, `width`, `height`, `n_classes` | Paint multi-class 2D scatter data with brush |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - ProgressBar: reference/progress-bar.md
       - PulsarChart: reference/pulsar-chart.md
       - ModuleTreeWidget: reference/module-tree.md
+      - WandbChart: reference/wandb-chart.md
       - Neo4jWidget: reference/neo4j-widget.md
       - ScatterWidget: reference/scatter-widget.md
       - Utils: reference/utils.md

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -151,7 +151,7 @@ Each widget page embeds a marimo-powered html-wasm export and links back to the 
 
 ## 3rd party widgets
 
-These widgets depend on 3rd party packages. They still ship with wigglystuff but have demos hosted on [molab](https://molab.marimo.io) because many of the dependencies are not compatible with WASM.(https://molab.marimo.io/notebooks/nb_K7QvvoASZErgKxwD8XSMWi).
+These widgets depend on 3rd party packages. They still ship with wigglystuff but have demos hosted on [molab](https://molab.marimo.io) because many of the dependencies are not compatible with WASM.
 
 <div class="widget-gallery">
 <div class="gallery-item">

--- a/mkdocs/reference/wandb-chart.md
+++ b/mkdocs/reference/wandb-chart.md
@@ -1,0 +1,18 @@
+# WandbChart API
+
+::: wigglystuff.wandb_chart.WandbChart
+
+## Synced traitlets
+
+| Traitlet | Type | Notes |
+| --- | --- | --- |
+| `api_key` | `str` | Your wandb API key. |
+| `entity` | `str` | The wandb entity (user or team). |
+| `project` | `str` | The wandb project name. |
+| `key` | `str` | The metric key to chart (e.g. `"loss"`). |
+| `poll_seconds` | `int \| None` | Seconds between polling updates, or `None` for manual refresh (default: 5). |
+| `smoothing_kind` | `str` | Type of smoothing: `"rolling"`, `"exponential"`, or `"gaussian"` (default: `"gaussian"`). |
+| `smoothing_param` | `float \| None` | Smoothing parameter, or `None` for no smoothing. |
+| `show_slider` | `bool` | Whether to show the smoothing slider (default: `True`). |
+| `width` | `int` | Chart width in pixels (default: 700). |
+| `height` | `int` | Chart height in pixels (default: 300). |


### PR DESCRIPTION
## Summary

- Create `mkdocs/reference/wandb-chart.md` with API autodocs and synced traitlets table
- Add WandbChart to `mkdocs.yml` navigation so it renders in the docs site
- Add WandbChart entry to `agents.md` reference table for LLM context
- Remove stray URL accidentally appended to the "3rd party widgets" paragraph in `mkdocs/index.md`

The WandbChart widget was fully implemented but its reference documentation page was never created and it was missing from the mkdocs navigation, causing broken links from the README, gallery, and llms.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)