### PR TITLE
Fix keystroke widget font fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.31] - 2026-02-19
+
+### Fixed
+- `KeystrokeWidget` canvas and metadata text now includes a generic `monospace` fallback in the font stack, preventing the browser from falling back to a serif font when named monospace fonts are unavailable.
+
 ## [0.2.30] - 2026-02-19
 
 ### Added

--- a/demos/keystroke.py
+++ b/demos/keystroke.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "marimo>=0.19.11",
+#     "wigglystuff==0.2.30",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.18.1"

--- a/wigglystuff/static/keystroke.css
+++ b/wigglystuff/static/keystroke.css
@@ -57,7 +57,7 @@
   align-items: center;
   justify-content: center;
   font-size: 16px;
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, SFMono, Consolas, "Liberation Mono";
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, SFMono, Consolas, "Liberation Mono", monospace;
   cursor: pointer;
   transition: border-color 0.2s ease, background-color 0.2s ease;
   outline: none;
@@ -78,5 +78,5 @@
 .keystroke-meta {
   font-size: 13px;
   color: var(--keystroke-muted, #6b7280);
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, SFMono, Consolas, "Liberation Mono";
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, SFMono, Consolas, "Liberation Mono", monospace;
 }


### PR DESCRIPTION
## Summary
- Add generic `monospace` fallback to keystroke canvas and metadata font stacks
- Prevents browser from falling back to serif fonts when named monospace fonts are unavailable
- Updates changelog with version 0.2.31

🤖 Generated with [Claude Code](https://claude.com/claude-code)