### PR TITLE
Point AltairWidget demo to molab

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ These widgets depend on 3rd party packages. They still ship with wigglystuff but
 <td align="center"><b>Neo4jWidget</b><br><a href="https://molab.marimo.io/notebooks/nb_ghifaw8nRCuDAgc1UTajXU"><img src="./mkdocs/assets/gallery/neo4j-widget.png" width="330"></a><br><a href="https://molab.marimo.io/notebooks/nb_ghifaw8nRCuDAgc1UTajXU">Demo</a> · <a href="https://koaning.github.io/wigglystuff/reference/neo4j-widget/">API</a> · <a href="https://koaning.github.io/wigglystuff/reference/neo4j-widget.md">MD</a></td>
 </tr>
 <tr>
-<td align="center"><b>AltairWidget</b><br><a href="https://koaning.github.io/wigglystuff/examples/altairwidget/"><img src="./mkdocs/assets/gallery/altairwidget.png" width="200"></a><br><a href="https://koaning.github.io/wigglystuff/examples/altairwidget/">Demo</a> · <a href="https://koaning.github.io/wigglystuff/reference/altair-widget/">API</a> · <a href="https://koaning.github.io/wigglystuff/reference/altair-widget.md">MD</a></td>
+<td align="center"><b>AltairWidget</b><br><a href="https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/altairwidget.py"><img src="./mkdocs/assets/gallery/altairwidget.png" width="200"></a><br><a href="https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/altairwidget.py">Demo</a> · <a href="https://koaning.github.io/wigglystuff/reference/altair-widget/">API</a> · <a href="https://koaning.github.io/wigglystuff/reference/altair-widget.md">MD</a></td>
 </tr>
 </table>

--- a/demos/altairwidget.py
+++ b/demos/altairwidget.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "altair==6.0.0",
+#     "marimo>=0.19.11",
+#     "numpy==2.4.2",
+#     "pandas==3.0.1",
+#     "wigglystuff==0.2.30",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.19.11"
@@ -34,6 +45,12 @@ def _(mo):
 
 
 @app.cell
+def _(wrapped):
+    wrapped
+    return
+
+
+@app.cell
 def _(amplitude, phase, widget):
     import altair as alt
     import numpy as np
@@ -56,12 +73,6 @@ def _(amplitude, phase, widget):
     )
 
     widget.chart = chart
-    return
-
-
-@app.cell
-def _(wrapped):
-    wrapped
     return
 
 

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -176,7 +176,7 @@ These widgets depend on 3rd party packages. They still ship with wigglystuff but
 </div>
 <div class="gallery-item">
 <div class="gallery-title">AltairWidget</div>
-<a href="examples/altairwidget/" class="gallery-img"><img src="assets/gallery/altairwidget.png" alt="AltairWidget"></a>
-<div class="gallery-links"><a href="examples/altairwidget/">Demo</a><a href="reference/altair-widget/">API</a><a href="reference/altair-widget.md">MD</a></div>
+<a href="https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/altairwidget.py" class="gallery-img"><img src="assets/gallery/altairwidget.png" alt="AltairWidget"></a>
+<div class="gallery-links"><a href="https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/altairwidget.py">Demo</a><a href="reference/altair-widget/">API</a><a href="reference/altair-widget.md">MD</a></div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
Updates the AltairWidget demo links in README and mkdocs gallery to point to the molab deployment instead of local docs. This ensures the demo is accessible and runnable for users.

## Changes
- Updated demo URL to `https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/altairwidget.py` in README.md and mkdocs/index.md
- Added Python script metadata to demos/altairwidget.py for molab compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)