### PR TITLE
Add ApiDoc widget for rendering Python API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.32] - 2026-02-25
+
+### Added
+- New `ApiDoc` widget for rendering Python class and function API documentation directly in notebooks. Introspects signatures, parameters, docstrings, methods, and properties via stdlib `inspect`. Features collapsible method/property sections, colored badges for class/function/classmethod/staticmethod/property, Python syntax highlighting in fenced code blocks, inline markdown (`**bold**`, `` `code` ``), copy-to-clipboard on code examples, and light/dark theme support.
+
 ## [0.2.31] - 2026-02-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.32] - 2026-02-25
+## [0.2.31] - 2026-02-19
 
 ### Added
 - New `ApiDoc` widget for rendering Python class and function API documentation directly in notebooks. Introspects signatures, parameters, docstrings, methods, and properties via stdlib `inspect`. Features collapsible method/property sections, colored badges for class/function/classmethod/staticmethod/property, Python syntax highlighting in fenced code blocks, inline markdown (`**bold**`, `` `code` ``), copy-to-clipboard on code examples, and light/dark theme support.
-
-## [0.2.31] - 2026-02-19
 
 ### Fixed
 - `KeystrokeWidget` canvas and metadata text now includes a generic `monospace` fallback in the font stack, preventing the browser from falling back to a serif font when named monospace fonts are unavailable.

--- a/agents.md
+++ b/agents.md
@@ -10,6 +10,7 @@ syncs back to Python.
 | Agent | Module/Class | Core traitlets | One-liner |
 | --- | --- | --- | --- |
 | AltairWidget | `wigglystuff.altair_widget.AltairWidget` | `spec`, `width`, `height` | Flicker-free Altair chart with smooth data updates |
+| ApiDoc | `wigglystuff.api_doc.ApiDoc` | `doc`, `width`, `show_private` | Renders API docs for Python classes/functions |
 | Slider2D | `wigglystuff.slider2d.Slider2D` | `x`, `y`, `x_bounds`, `y_bounds`, `width`, `height` | 2D pointer for coupled parameters |
 | ChartPuck | `wigglystuff.chart_puck.ChartPuck` | `x`, `y`, `x_bounds`, `y_bounds`, `axes_pixel_bounds`, `width`, `height`, `chart_base64`, `puck_radius`, `puck_color`, `throttle` | Draggable puck overlay for matplotlib charts |
 | ChartSelect | `wigglystuff.chart_select.ChartSelect` | `mode`, `selection`, `has_selection`, `x_bounds`, `y_bounds`, `axes_pixel_bounds`, `width`, `height`, `chart_base64`, `selection_color`, `selection_opacity` | Box/lasso selection on matplotlib charts |
@@ -64,6 +65,11 @@ syncs back to Python.
 - Each widget has a demo marimo notebook in the `demos/` folder (e.g.,
   `demos/colorpicker.py`). When adding a new widget, create a corresponding
   demo notebook. Run demos with `marimo edit demos/<widget>.py`.
+- **Always smoke-test new or modified widget code** with
+  `uv run python -c "..."` to instantiate the widget, exercise traitlet changes,
+  and check edge cases (built-ins, empty inputs, toggles). `marimo check` only
+  validates notebook structure—it does **not** execute code, so it catches zero
+  runtime bugs.
 - **Always run `uv run marimo check demos/<notebook>.py`** after editing a demo
   notebook to verify it parses correctly and has no cell dependency issues.
 - Dumber is better. Prefer obvious, direct code over clever abstractions—someone

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
-    "setup": "make install"
+    "setup": "make install",
+    "run": "uv run marimo edit --watch demos"
   }
 }

--- a/demos/apidoc.py
+++ b/demos/apidoc.py
@@ -145,8 +145,8 @@ def train_model(
 
 
 @app.cell
-def _(ApiDoc, mo):
-    mo.ui.anywidget(ApiDoc(train_model))
+def _(ApiDoc):
+    ApiDoc(train_model)
     return
 
 

--- a/demos/apidoc.py
+++ b/demos/apidoc.py
@@ -1,0 +1,154 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo>=0.19.7",
+#     "wigglystuff==0.2.23",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.20.2"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # ApiDoc
+
+    Renders API documentation for Python classes and functions directly in a notebook.
+    It inspects signatures, docstrings, methods, and properties automatically.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _():
+    from wigglystuff import ApiDoc
+
+    return (ApiDoc,)
+
+
+@app.class_definition
+class Estimator:
+    """A simple estimator that fits a linear model.
+
+    This estimator demonstrates the ApiDoc widget by providing
+    typed parameters, methods with docstrings, and properties.
+
+    **Example:**
+
+    ```python
+    est = Estimator(alpha=0.5)
+    est.fit([[1, 2], [3, 4]], [0, 1])
+    print(est.predict([[5, 6]]))
+    ```
+    """
+
+    def __init__(self, alpha: float = 1.0, fit_intercept: bool = True, max_iter: int = 100):
+        """Create an Estimator.
+
+        Args:
+            alpha: Regularization strength.
+            fit_intercept: Whether to fit an intercept term.
+            max_iter: Maximum number of iterations.
+        """
+        self.alpha = alpha
+        self.fit_intercept = fit_intercept
+        self.max_iter = max_iter
+        self._coef = None
+
+    def fit(self, X: list, y: list) -> "Estimator":
+        """Fit the model to training data.
+
+        Args:
+            X: Training features.
+            y: Target values.
+
+        Returns:
+            self
+        """
+        self._coef = [0.0] * len(X[0]) if X else []
+        return self
+
+    def predict(self, X: list) -> list:
+        """Generate predictions for new data.
+
+        Args:
+            X: Input features.
+
+        Returns:
+            Predicted values.
+        """
+        return [0.0] * len(X)
+
+    @property
+    def coef(self) -> list:
+        """The fitted coefficients after calling fit()."""
+        return self._coef
+
+    @classmethod
+    def from_config(cls, config: dict) -> "Estimator":
+        """Create an estimator from a configuration dictionary.
+
+        Args:
+            config: Dictionary of keyword arguments.
+        """
+        return cls(**config)
+
+
+@app.cell
+def _(ApiDoc, mo):
+    mo.ui.anywidget(ApiDoc(Estimator))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    `ApiDoc` also works on standalone functions.
+    """)
+    return
+
+
+@app.function
+def train_model(
+    data: list,
+    epochs: int = 10,
+    learning_rate: float = 0.01,
+    *,
+    verbose: bool = False,
+) -> dict:
+    """Train a model on the provided data.
+
+    Runs gradient descent for the given number of epochs and returns
+    a dictionary with training history.
+
+    **Args:**
+    - `data`: Training samples.
+    - `epochs`: Number of training epochs.
+    - `learning_rate`: Step size for gradient descent.
+    - `verbose`: If True, print progress each epoch.
+
+    Returns:
+        A dict with keys 'loss' and 'epochs'.
+    """
+    return {"loss": 0.0, "epochs": epochs}
+
+
+@app.cell
+def _(ApiDoc, mo):
+    mo.ui.anywidget(ApiDoc(train_model))
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/wigglystuff/__init__.py
+++ b/wigglystuff/__init__.py
@@ -3,6 +3,7 @@
 import importlib.metadata
 
 from .altair_widget import AltairWidget
+from .api_doc import ApiDoc
 from .cell_tour import CellTour
 from .chart_puck import ChartPuck
 from .chart_select import ChartSelect
@@ -34,6 +35,7 @@ __version__ = importlib.metadata.version("wigglystuff")
 
 __all__ = [
     "AltairWidget",
+    "ApiDoc",
     "CellTour",
     "ChartPuck",
     "ChartSelect",

--- a/wigglystuff/api_doc.py
+++ b/wigglystuff/api_doc.py
@@ -94,10 +94,10 @@ def _extract_doc(obj, show_private=False):
     """Main entry point: extract documentation structure from a class or function."""
     if isinstance(obj, type):
         return _extract_class_doc(obj, show_private)
-    elif callable(obj):
+    elif inspect.isfunction(obj) or inspect.isbuiltin(obj) or inspect.ismethod(obj):
         return _extract_function_doc(obj)
     else:
-        # Try the object's type
+        # Callable instances, plain objects — document their class
         return _extract_class_doc(type(obj), show_private)
 
 

--- a/wigglystuff/api_doc.py
+++ b/wigglystuff/api_doc.py
@@ -1,0 +1,183 @@
+"""ApiDoc widget for rendering Python class/function documentation in notebooks."""
+
+import inspect
+from pathlib import Path
+
+import anywidget
+import traitlets
+
+
+def _format_annotation(ann):
+    """Best-effort conversion of a type annotation to a readable string."""
+    if ann is inspect.Parameter.empty:
+        return ""
+    if isinstance(ann, type):
+        return ann.__qualname__
+    return str(ann)
+
+
+def _extract_params(sig):
+    """Extract parameter info from an inspect.Signature."""
+    params = []
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        entry = {"name": name}
+        entry["annotation"] = _format_annotation(param.annotation)
+        if param.default is not inspect.Parameter.empty:
+            entry["default"] = repr(param.default)
+        else:
+            entry["default"] = ""
+        kind = param.kind
+        if kind == inspect.Parameter.VAR_POSITIONAL:
+            entry["name"] = f"*{name}"
+        elif kind == inspect.Parameter.VAR_KEYWORD:
+            entry["name"] = f"**{name}"
+        elif kind == inspect.Parameter.KEYWORD_ONLY:
+            entry["keyword_only"] = True
+        params.append(entry)
+    return params
+
+
+def _extract_methods(cls, show_private):
+    """Extract methods from a class, skipping object builtins."""
+    methods = []
+    object_attrs = set(dir(object))
+    for name in sorted(dir(cls)):
+        if name in object_attrs:
+            continue
+        if name.startswith("__") and name.endswith("__"):
+            continue
+        if name.startswith("_") and not show_private:
+            continue
+        try:
+            attr = getattr(cls, name)
+        except Exception:
+            continue
+        if not callable(attr) and not isinstance(attr, (classmethod, staticmethod)):
+            continue
+        # Skip properties
+        if isinstance(inspect.getattr_static(cls, name, None), property):
+            continue
+        entry = {"name": name, "docstring": inspect.getdoc(attr) or ""}
+        # Detect classmethod/staticmethod
+        raw = inspect.getattr_static(cls, name, None)
+        if isinstance(raw, classmethod):
+            entry["decorator"] = "classmethod"
+        elif isinstance(raw, staticmethod):
+            entry["decorator"] = "staticmethod"
+        try:
+            sig = inspect.signature(attr)
+            entry["signature"] = str(sig)
+            entry["parameters"] = _extract_params(sig)
+        except (ValueError, TypeError):
+            entry["signature"] = "(...)"
+            entry["parameters"] = []
+        methods.append(entry)
+    return methods
+
+
+def _extract_properties(cls):
+    """Extract property descriptors from a class."""
+    props = []
+    for name in sorted(dir(cls)):
+        raw = inspect.getattr_static(cls, name, None)
+        if isinstance(raw, property):
+            props.append({
+                "name": name,
+                "docstring": inspect.getdoc(raw) or "",
+            })
+    return props
+
+
+def _extract_doc(obj, show_private=False):
+    """Main entry point: extract documentation structure from a class or function."""
+    if isinstance(obj, type):
+        return _extract_class_doc(obj, show_private)
+    elif callable(obj):
+        return _extract_function_doc(obj)
+    else:
+        # Try the object's type
+        return _extract_class_doc(type(obj), show_private)
+
+
+def _extract_class_doc(cls, show_private):
+    """Extract documentation structure from a class."""
+    module = cls.__module__
+    if module == "__main__":
+        module = ""
+    doc = {
+        "kind": "class",
+        "name": cls.__name__,
+        "module": module,
+        "docstring": inspect.getdoc(cls) or "",
+        "bases": [b.__name__ for b in cls.__bases__ if b is not object],
+    }
+    try:
+        sig = inspect.signature(cls)
+        doc["signature"] = str(sig)
+        doc["parameters"] = _extract_params(sig)
+    except (ValueError, TypeError):
+        doc["signature"] = "(...)"
+        doc["parameters"] = []
+    doc["methods"] = _extract_methods(cls, show_private)
+    doc["properties"] = _extract_properties(cls)
+    return doc
+
+
+def _extract_function_doc(func):
+    """Extract documentation structure from a function."""
+    module = getattr(func, "__module__", "")
+    if module == "__main__":
+        module = ""
+    doc = {
+        "kind": "function",
+        "name": func.__name__,
+        "module": module,
+        "docstring": inspect.getdoc(func) or "",
+    }
+    try:
+        sig = inspect.signature(func)
+        doc["signature"] = str(sig)
+        doc["parameters"] = _extract_params(sig)
+    except (ValueError, TypeError):
+        doc["signature"] = "(...)"
+        doc["parameters"] = []
+    return doc
+
+
+class ApiDoc(anywidget.AnyWidget):
+    """Renders API documentation for a Python class or function in a notebook.
+
+    Examples:
+        ```python
+        from wigglystuff import ApiDoc
+
+        ApiDoc(MyClass)
+        ```
+    """
+
+    _esm = Path(__file__).parent / "static" / "api-doc.js"
+    _css = Path(__file__).parent / "static" / "api-doc.css"
+
+    doc = traitlets.Dict(default_value={}).tag(sync=True)
+    width = traitlets.Int(default_value=700).tag(sync=True)
+    show_private = traitlets.Bool(default_value=False).tag(sync=True)
+
+    def __init__(self, obj=None, *, width=700, show_private=False):
+        """Create an ApiDoc widget.
+
+        Args:
+            obj: A Python class or function to document.
+            width: Maximum pixel width for the widget.
+            show_private: Whether to include _-prefixed methods.
+        """
+        self._obj = obj
+        super().__init__(width=width, show_private=show_private)
+        if obj is not None:
+            self.doc = _extract_doc(obj, show_private)
+
+    @traitlets.observe("show_private")
+    def _reextract(self, change):
+        if getattr(self, "_obj", None) is not None:
+            self.doc = _extract_doc(self._obj, change["new"])

--- a/wigglystuff/static/api-doc.css
+++ b/wigglystuff/static/api-doc.css
@@ -1,0 +1,349 @@
+.api-doc-root {
+  --ad-bg: #ffffff;
+  --ad-text: #1a1a1a;
+  --ad-text-secondary: #555555;
+  --ad-text-muted: #999999;
+  --ad-border: #e0e0e0;
+  --ad-code-bg: #f5f5f7;
+  --ad-code-text: #1a1a1a;
+  --ad-badge-bg: #f0f0f2;
+  --ad-badge-text: #555555;
+  --ad-table-header-bg: #f8f8fa;
+  --ad-table-stripe: #fafafa;
+  --ad-link: #2563eb;
+  --ad-hl-kw: #cf222e;
+  --ad-hl-str: #0a3069;
+  --ad-hl-num: #0550ae;
+  --ad-hl-comment: #6e7781;
+  --ad-hl-builtin: #8250df;
+
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  color: var(--ad-text);
+  background: var(--ad-bg);
+  padding: 16px;
+  line-height: 1.6;
+  color-scheme: light dark;
+}
+
+.api-doc-root.dark-mode {
+  --ad-bg: #1a1a1a;
+  --ad-text: #e0e0e0;
+  --ad-text-secondary: #aaaaaa;
+  --ad-text-muted: #666666;
+  --ad-border: #333333;
+  --ad-code-bg: #2a2a2e;
+  --ad-code-text: #e0e0e0;
+  --ad-badge-bg: #2a2a2e;
+  --ad-badge-text: #aaaaaa;
+  --ad-table-header-bg: #222225;
+  --ad-table-stripe: #1e1e20;
+  --ad-link: #60a5fa;
+  --ad-hl-kw: #ff7b72;
+  --ad-hl-str: #a5d6ff;
+  --ad-hl-num: #79c0ff;
+  --ad-hl-comment: #8b949e;
+  --ad-hl-builtin: #d2a8ff;
+}
+
+/* Title: module.ClassName */
+.ad-title {
+  margin: 0 0 4px 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.ad-module {
+  font-weight: 400;
+  color: var(--ad-text-muted);
+}
+
+/* Bases line */
+.ad-bases {
+  font-size: 13px;
+  color: var(--ad-text-secondary);
+  margin-bottom: 8px;
+}
+
+.ad-bases code {
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 12px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--ad-code-bg);
+  color: var(--ad-code-text);
+}
+
+/* Signature block */
+.ad-signature {
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 13px;
+  background: var(--ad-code-bg);
+  color: var(--ad-code-text);
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Parameter table */
+.ad-param-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+.ad-param-table th {
+  text-align: left;
+  padding: 6px 10px;
+  background: var(--ad-table-header-bg);
+  color: var(--ad-text-secondary);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--ad-border);
+}
+
+.ad-param-table td {
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--ad-border);
+  vertical-align: top;
+}
+
+.ad-param-table tr:nth-child(even) td {
+  background: var(--ad-table-stripe);
+}
+
+.ad-param-table code {
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 12px;
+}
+
+/* Docstring block */
+.ad-docstring {
+  font-size: 13px;
+  color: var(--ad-text-secondary);
+  margin-bottom: 16px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+/* Inline code in docstrings */
+.ad-inline-code {
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 12px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--ad-code-bg);
+  color: var(--ad-code-text);
+}
+
+/* Code block wrapper (holds pre + copy button) */
+.ad-code-wrapper {
+  position: relative;
+  margin: 4px 0;
+  white-space: normal;
+}
+
+/* Fenced code blocks inside docstrings */
+.ad-code-block {
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 12px;
+  background: var(--ad-code-bg);
+  color: var(--ad-code-text);
+  padding: 10px 12px;
+  border-radius: 6px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  line-height: 1.45;
+}
+
+.ad-code-block code {
+  font-family: inherit;
+  font-size: inherit;
+  background: none;
+  padding: 0;
+}
+
+/* Copy button */
+.ad-copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--ad-border);
+  background: var(--ad-bg);
+  color: var(--ad-text-secondary);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.ad-code-wrapper:hover .ad-copy-btn {
+  opacity: 1;
+}
+
+.ad-copy-btn:hover {
+  background: var(--ad-code-bg);
+}
+
+/* Syntax highlighting */
+.ad-hl-kw { color: var(--ad-hl-kw); }
+.ad-hl-str { color: var(--ad-hl-str); }
+.ad-hl-num { color: var(--ad-hl-num); }
+.ad-hl-comment { color: var(--ad-hl-comment); font-style: italic; }
+.ad-hl-builtin { color: var(--ad-hl-builtin); }
+
+/* Section headings */
+.ad-section-heading {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ad-text);
+  margin: 20px 0 8px 0;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--ad-border);
+}
+
+/* Method/property collapsible header */
+.ad-method-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.ad-method-header:hover {
+  background: var(--ad-code-bg);
+}
+
+/* Toggle chevron */
+.ad-toggle {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: var(--ad-text-muted);
+  transition: transform 0.15s ease;
+}
+
+.ad-toggle.expanded {
+  transform: rotate(90deg);
+}
+
+/* Collapsible body */
+.ad-method-body {
+  margin-left: 22px;
+  padding-left: 10px;
+  border-left: 1px solid var(--ad-border);
+}
+
+.ad-method-body.collapsed {
+  display: none;
+}
+
+/* Method heading */
+.ad-method-heading {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ad-text);
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+}
+
+/* Decorator / kind badges — shared base */
+.ad-badge,
+.ad-kind {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.ad-badge {
+  margin-left: 6px;
+}
+
+/* classmethod */
+.ad-badge.ad-badge-classmethod {
+  background: #fef3c7;
+  color: #92400e;
+}
+.dark-mode .ad-badge.ad-badge-classmethod {
+  background: #451a03;
+  color: #fbbf24;
+}
+
+/* staticmethod */
+.ad-badge.ad-badge-staticmethod {
+  background: #ccfbf1;
+  color: #115e59;
+}
+.dark-mode .ad-badge.ad-badge-staticmethod {
+  background: #042f2e;
+  color: #5eead4;
+}
+
+/* property */
+.ad-badge.ad-badge-property {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+.dark-mode .ad-badge.ad-badge-property {
+  background: #2e1065;
+  color: #c4b5fd;
+}
+
+/* Property name */
+.ad-property-heading {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ad-text);
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+}
+
+/* Divider between methods */
+.ad-method-block {
+  margin-bottom: 4px;
+}
+
+/* Kind label (class / function) */
+.ad-kind {
+  margin-left: 8px;
+}
+
+/* class */
+.ad-kind-class {
+  background: #dbeafe;
+  color: #1e40af;
+}
+.dark-mode .ad-kind-class {
+  background: #1e3a5f;
+  color: #93c5fd;
+}
+
+/* function */
+.ad-kind-function {
+  background: #dcfce7;
+  color: #166534;
+}
+.dark-mode .ad-kind-function {
+  background: #14532d;
+  color: #86efac;
+}

--- a/wigglystuff/static/api-doc.js
+++ b/wigglystuff/static/api-doc.js
@@ -1,0 +1,423 @@
+// Simple Python syntax highlighter for code blocks in docstrings.
+// No dependencies — just regex-based token coloring.
+const PY_KEYWORDS = new Set([
+  "False", "None", "True", "and", "as", "assert", "async", "await",
+  "break", "class", "continue", "def", "del", "elif", "else", "except",
+  "finally", "for", "from", "global", "if", "import", "in", "is",
+  "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try",
+  "while", "with", "yield",
+]);
+
+const PY_BUILTINS = new Set([
+  "print", "len", "range", "int", "str", "float", "list", "dict", "set",
+  "tuple", "bool", "type", "isinstance", "super", "property", "classmethod",
+  "staticmethod", "enumerate", "zip", "map", "filter", "sorted", "reversed",
+  "open", "hasattr", "getattr", "setattr", "repr", "iter", "next", "self",
+]);
+
+function highlightPython(code) {
+  // Tokenize with a single regex, then wrap matches in spans.
+  // Order matters: strings before comments before keywords.
+  const pattern = /("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(#[^\n]*)|\b(\d+(?:\.\d+)?)\b|(\b[A-Za-z_]\w*\b)/g;
+  let result = "";
+  let last = 0;
+  let match;
+  while ((match = pattern.exec(code)) !== null) {
+    // Append text between matches (escaped)
+    result += escapeHtml(code.slice(last, match.index));
+    last = match.index + match[0].length;
+
+    if (match[1]) {
+      // String
+      result += '<span class="ad-hl-str">' + escapeHtml(match[1]) + "</span>";
+    } else if (match[2]) {
+      // Comment
+      result += '<span class="ad-hl-comment">' + escapeHtml(match[2]) + "</span>";
+    } else if (match[3]) {
+      // Number
+      result += '<span class="ad-hl-num">' + escapeHtml(match[3]) + "</span>";
+    } else if (match[4]) {
+      // Identifier — check if keyword or builtin
+      if (PY_KEYWORDS.has(match[4])) {
+        result += '<span class="ad-hl-kw">' + escapeHtml(match[4]) + "</span>";
+      } else if (PY_BUILTINS.has(match[4])) {
+        result += '<span class="ad-hl-builtin">' + escapeHtml(match[4]) + "</span>";
+      } else {
+        result += escapeHtml(match[4]);
+      }
+    }
+  }
+  result += escapeHtml(code.slice(last));
+  return result;
+}
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function buildParamTable(params) {
+  if (!params || params.length === 0) return null;
+
+  const table = document.createElement("table");
+  table.className = "ad-param-table";
+
+  const thead = document.createElement("thead");
+  const headerRow = document.createElement("tr");
+  for (const col of ["Name", "Type", "Default"]) {
+    const th = document.createElement("th");
+    th.textContent = col;
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  for (const p of params) {
+    const tr = document.createElement("tr");
+    const tdName = document.createElement("td");
+    const nameCode = document.createElement("code");
+    nameCode.textContent = p.name;
+    tdName.appendChild(nameCode);
+    tr.appendChild(tdName);
+
+    const tdType = document.createElement("td");
+    if (p.annotation) {
+      const typeCode = document.createElement("code");
+      typeCode.textContent = p.annotation;
+      tdType.appendChild(typeCode);
+    }
+    tr.appendChild(tdType);
+
+    const tdDefault = document.createElement("td");
+    if (p.default) {
+      const defCode = document.createElement("code");
+      defCode.textContent = p.default;
+      tdDefault.appendChild(defCode);
+    }
+    tr.appendChild(tdDefault);
+
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  return table;
+}
+
+// Parse docstring text into a mix of plain text and fenced code blocks.
+// Returns an array of {type: "text"|"code", content, lang?} segments.
+function parseDocstring(text) {
+  if (!text) return [];
+  const segments = [];
+  // Match fenced code blocks with optional leading whitespace
+  const fencePattern = /^[ \t]*```(\w*)\s*\n([\s\S]*?)^[ \t]*```\s*$/gm;
+  let last = 0;
+  let match;
+  while ((match = fencePattern.exec(text)) !== null) {
+    if (match.index > last) {
+      const before = text.slice(last, match.index).replace(/\n+$/, "");
+      if (before) segments.push({ type: "text", content: before });
+    }
+    // Dedent the code content: strip common leading whitespace
+    let code = match[2];
+    const lines = code.split("\n");
+    const indents = lines.filter(l => l.trim()).map(l => l.match(/^(\s*)/)[1].length);
+    const minIndent = indents.length > 0 ? Math.min(...indents) : 0;
+    if (minIndent > 0) {
+      code = lines.map(l => l.slice(minIndent)).join("\n");
+    }
+    // Trim trailing whitespace from code
+    code = code.replace(/\s+$/, "");
+    segments.push({ type: "code", content: code, lang: match[1] || "python" });
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) {
+    const after = text.slice(last).replace(/^\n+/, "");
+    if (after) segments.push({ type: "text", content: after });
+  }
+  return segments;
+}
+
+// Render inline markdown: **bold** and `code`
+function renderInlineMarkdown(text, parent) {
+  const pattern = /(\*\*(.+?)\*\*)|(`([^`]+)`)/g;
+  let last = 0;
+  let match;
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > last) {
+      parent.appendChild(document.createTextNode(text.slice(last, match.index)));
+    }
+    if (match[1]) {
+      const bold = document.createElement("strong");
+      bold.textContent = match[2];
+      parent.appendChild(bold);
+    } else if (match[3]) {
+      const code = document.createElement("code");
+      code.className = "ad-inline-code";
+      code.textContent = match[4];
+      parent.appendChild(code);
+    }
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) {
+    parent.appendChild(document.createTextNode(text.slice(last)));
+  }
+}
+
+function buildDocstring(text) {
+  if (!text) return null;
+  const segments = parseDocstring(text);
+  const wrapper = document.createElement("div");
+  wrapper.className = "ad-docstring";
+  for (const seg of segments) {
+    if (seg.type === "text") {
+      const span = document.createElement("span");
+      renderInlineMarkdown(seg.content, span);
+      wrapper.appendChild(span);
+    } else {
+      const codeWrapper = document.createElement("div");
+      codeWrapper.className = "ad-code-wrapper";
+
+      const pre = document.createElement("pre");
+      pre.className = "ad-code-block";
+      const code = document.createElement("code");
+      if (seg.lang === "python" || seg.lang === "py" || seg.lang === "") {
+        code.innerHTML = highlightPython(seg.content);
+      } else {
+        code.textContent = seg.content;
+      }
+      pre.appendChild(code);
+
+      const copyBtn = document.createElement("button");
+      copyBtn.className = "ad-copy-btn";
+      copyBtn.textContent = "Copy";
+      copyBtn.addEventListener("click", () => {
+        navigator.clipboard.writeText(seg.content).then(() => {
+          copyBtn.textContent = "Copied!";
+          setTimeout(() => { copyBtn.textContent = "Copy"; }, 1500);
+        });
+      });
+
+      codeWrapper.appendChild(pre);
+      codeWrapper.appendChild(copyBtn);
+      wrapper.appendChild(codeWrapper);
+    }
+  }
+  return wrapper;
+}
+
+function buildMethodBlock(method) {
+  const block = document.createElement("div");
+  block.className = "ad-method-block";
+
+  const header = document.createElement("div");
+  header.className = "ad-method-header";
+
+  const toggle = document.createElement("span");
+  toggle.className = "ad-toggle";
+  toggle.textContent = "\u25B6";
+  header.appendChild(toggle);
+
+  const heading = document.createElement("span");
+  heading.className = "ad-method-heading";
+  heading.textContent = method.name + (method.signature || "()");
+  header.appendChild(heading);
+
+  if (method.decorator) {
+    const badge = document.createElement("span");
+    badge.className = "ad-badge ad-badge-" + method.decorator;
+    badge.textContent = method.decorator;
+    header.appendChild(badge);
+  }
+
+  block.appendChild(header);
+
+  // Collapsible body
+  const body = document.createElement("div");
+  body.className = "ad-method-body collapsed";
+
+  const docEl = buildDocstring(method.docstring);
+  if (docEl) body.appendChild(docEl);
+
+  const tableEl = buildParamTable(method.parameters);
+  if (tableEl) body.appendChild(tableEl);
+
+  block.appendChild(body);
+
+  header.addEventListener("click", () => {
+    body.classList.toggle("collapsed");
+    toggle.classList.toggle("expanded");
+  });
+
+  return block;
+}
+
+function buildPropertyBlock(prop) {
+  const block = document.createElement("div");
+  block.className = "ad-method-block";
+
+  const header = document.createElement("div");
+  header.className = "ad-method-header";
+
+  const toggle = document.createElement("span");
+  toggle.className = "ad-toggle";
+  toggle.textContent = "\u25B6";
+  header.appendChild(toggle);
+
+  const heading = document.createElement("span");
+  heading.className = "ad-property-heading";
+  heading.textContent = prop.name;
+  header.appendChild(heading);
+
+  const badge = document.createElement("span");
+  badge.className = "ad-badge ad-badge-property";
+  badge.textContent = "property";
+  header.appendChild(badge);
+
+  block.appendChild(header);
+
+  const body = document.createElement("div");
+  body.className = "ad-method-body collapsed";
+
+  const docEl = buildDocstring(prop.docstring);
+  if (docEl) body.appendChild(docEl);
+
+  block.appendChild(body);
+
+  header.addEventListener("click", () => {
+    body.classList.toggle("collapsed");
+    toggle.classList.toggle("expanded");
+  });
+
+  return block;
+}
+
+function render({ model, el }) {
+  el.classList.add("api-doc-root");
+
+  // Theme detection
+  function detectTheme() {
+    const html = document.documentElement;
+    const body = document.body;
+    const isDark =
+      html.classList.contains("dark") ||
+      body.classList.contains("dark") ||
+      html.getAttribute("data-theme") === "dark" ||
+      body.getAttribute("data-theme") === "dark" ||
+      html.getAttribute("data-color-mode") === "dark" ||
+      body.getAttribute("data-color-mode") === "dark";
+    if (isDark) {
+      el.classList.add("dark-mode");
+    } else {
+      el.classList.remove("dark-mode");
+    }
+  }
+  detectTheme();
+
+  const observer = new MutationObserver(detectTheme);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class", "data-theme", "data-color-mode"],
+  });
+  observer.observe(document.body, {
+    attributes: true,
+    attributeFilter: ["class", "data-theme", "data-color-mode"],
+  });
+
+  const container = document.createElement("div");
+  el.appendChild(container);
+
+  function draw() {
+    container.innerHTML = "";
+    const doc = model.get("doc");
+    const width = model.get("width") || 700;
+    container.style.maxWidth = width + "px";
+
+    if (!doc || !doc.name) return;
+
+    // Title: module.Name
+    const title = document.createElement("h2");
+    title.className = "ad-title";
+    if (doc.module) {
+      const moduleSpan = document.createElement("span");
+      moduleSpan.className = "ad-module";
+      moduleSpan.textContent = doc.module + ".";
+      title.appendChild(moduleSpan);
+    }
+    const nameText = document.createTextNode(doc.name);
+    title.appendChild(nameText);
+
+    // Kind badge
+    const kindBadge = document.createElement("span");
+    kindBadge.className = "ad-kind ad-kind-" + doc.kind;
+    kindBadge.textContent = doc.kind;
+    title.appendChild(kindBadge);
+
+    container.appendChild(title);
+
+    // Bases line (class only)
+    if (doc.bases && doc.bases.length > 0) {
+      const basesDiv = document.createElement("div");
+      basesDiv.className = "ad-bases";
+      basesDiv.appendChild(document.createTextNode("Bases: "));
+      for (let i = 0; i < doc.bases.length; i++) {
+        if (i > 0) basesDiv.appendChild(document.createTextNode(", "));
+        const code = document.createElement("code");
+        code.textContent = doc.bases[i];
+        basesDiv.appendChild(code);
+      }
+      container.appendChild(basesDiv);
+    }
+
+    // Constructor / function signature
+    if (doc.signature) {
+      const sigDiv = document.createElement("div");
+      sigDiv.className = "ad-signature";
+      sigDiv.textContent = doc.name + doc.signature;
+      container.appendChild(sigDiv);
+    }
+
+    // Parameter table
+    const paramTable = buildParamTable(doc.parameters);
+    if (paramTable) container.appendChild(paramTable);
+
+    // Docstring
+    const docEl = buildDocstring(doc.docstring);
+    if (docEl) container.appendChild(docEl);
+
+    // Methods section (class only)
+    if (doc.methods && doc.methods.length > 0) {
+      const methodsHeading = document.createElement("h3");
+      methodsHeading.className = "ad-section-heading";
+      methodsHeading.textContent = "Methods";
+      container.appendChild(methodsHeading);
+
+      for (const method of doc.methods) {
+        container.appendChild(buildMethodBlock(method));
+      }
+    }
+
+    // Properties section (class only)
+    if (doc.properties && doc.properties.length > 0) {
+      const propsHeading = document.createElement("h3");
+      propsHeading.className = "ad-section-heading";
+      propsHeading.textContent = "Properties";
+      container.appendChild(propsHeading);
+
+      for (const prop of doc.properties) {
+        container.appendChild(buildPropertyBlock(prop));
+      }
+    }
+  }
+
+  draw();
+  model.on("change:doc", draw);
+  model.on("change:width", draw);
+
+  return () => {
+    observer.disconnect();
+  };
+}
+
+export default { render };


### PR DESCRIPTION
## Summary
Renders class/function signatures, parameters, docstrings with markdown and syntax highlighting, methods, and properties. Features collapsible method/property details, colored badges for kind/decorator types, and copy buttons on code examples.

## Key Features
- Extracts documentation via stdlib `inspect` module
- Markdown support in docstrings (`**bold**`, `` `code` ``)
- Syntax-highlighted Python code blocks (fenced)
- Collapsible methods and properties
- Light/dark theme support
- Copy-to-clipboard buttons on code examples
- Strips `__main__` module paths

## Testing
- Smoke-tested instantiation, traitlet changes, edge cases (built-ins, private methods toggle)
- Demo marimo notebook with class and function examples
- All changes pass `marimo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)