### PR TITLE
Pin @pierre/diffs to ^1.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "wigglystuff",
       "dependencies": {
         "@anywidget/react": "^0.1.0",
-        "@pierre/diffs": "latest",
+        "@pierre/diffs": "^1.0.11",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/themes": "^3.2.1",
         "driver.js": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "esbuild": "^0.25.1",
     "radix-ui": "^1.1.3",
     "react": "^19.0.0",
-    "@pierre/diffs": "latest",
+    "@pierre/diffs": "^1.0.11",
     "three": "^0.170.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pins the @pierre/diffs dependency to an explicit version range (^1.0.11) instead of using "latest".

This fixes non-deterministic builds where CI and local installs could resolve to different versions on different days. The resolved version remains 1.0.11, ensuring build output stays stable.

Resolves #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)