### PR TITLE
Fix AltairWidget for layered/multi-dataset specs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,20 @@ jobs:
           python -m pip install --upgrade uv
           uv venv
           uv pip install -e ".[test-browser]"
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(uv run python -c 'import playwright; print(playwright.__version__)')" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.pw-version.outputs.version }}-chromium
       - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: uv run playwright install chromium --with-deps
+      - name: Install Playwright system deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: uv run playwright install-deps chromium
       - name: Pytest (browser tests)
         run: uv run pytest tests/test_browser -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - `KeystrokeWidget` canvas and metadata text now includes a generic `monospace` fallback in the font stack, preventing the browser from falling back to a serif font when named monospace fonts are unavailable.
+- `AltairWidget` now correctly renders layered and concatenated Altair charts that use multiple datasets. Previously, `prepareSpec` dropped all but the first dataset, breaking layer-level data references.
 
 ## [0.2.30] - 2026-02-19
 

--- a/demos/altairwidget.py
+++ b/demos/altairwidget.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.19.11"
+__generated_with = "0.20.2"
 app = marimo.App(width="medium")
 
 
@@ -88,7 +88,9 @@ def _(alt, amplitude, np, pd, phase, widget):
 
 @app.cell
 def _(mo):
-    mo.md("""## Layered chart demo""")
+    mo.md("""
+    ## Layered chart demo
+    """)
     return
 
 
@@ -99,7 +101,7 @@ def _(AltairWidget):
 
 
 @app.cell
-def _(mo, layered_widget):
+def _(layered_widget, mo):
     layered_wrapped = mo.ui.anywidget(layered_widget)
     return (layered_wrapped,)
 
@@ -119,7 +121,7 @@ def _(mo):
 
 @app.cell
 def _(alt, freq, layered_widget, np, pd):
-    _x = np.linspace(0, 4 * np.pi, 80)
+    _x = np.linspace(0, 4 * np.pi, 800)
     _df_sin = pd.DataFrame({"x": _x, "y": np.sin(freq.value * _x)})
     _df_cos = pd.DataFrame({"x": _x, "y": np.cos(freq.value * _x)})
 
@@ -141,6 +143,11 @@ def _(alt, freq, layered_widget, np, pd):
     )
 
     layered_widget.chart = (_c1 + _c2).properties(width=500, height=400)
+    return
+
+
+@app.cell
+def _():
     return
 
 

--- a/demos/altairwidget.py
+++ b/demos/altairwidget.py
@@ -24,8 +24,22 @@ def _():
 
 @app.cell
 def _():
+    import altair as alt
+    import numpy as np
+    import pandas as pd
+
+    return alt, np, pd
+
+
+@app.cell
+def _():
     from wigglystuff import AltairWidget
 
+    return (AltairWidget,)
+
+
+@app.cell
+def _(AltairWidget):
     widget = AltairWidget(width=500, height=400)
     return (widget,)
 
@@ -51,11 +65,7 @@ def _(wrapped):
 
 
 @app.cell
-def _(amplitude, phase, widget):
-    import altair as alt
-    import numpy as np
-    import pandas as pd
-
+def _(alt, amplitude, np, pd, phase, widget):
     x = np.linspace(0, 4 * np.pi, 80)
     y = amplitude.value * np.sin(x + phase.value)
 
@@ -73,6 +83,64 @@ def _(amplitude, phase, widget):
     )
 
     widget.chart = chart
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## Layered chart demo""")
+    return
+
+
+@app.cell
+def _(AltairWidget):
+    layered_widget = AltairWidget(width=500, height=400)
+    return (layered_widget,)
+
+
+@app.cell
+def _(mo, layered_widget):
+    layered_wrapped = mo.ui.anywidget(layered_widget)
+    return (layered_wrapped,)
+
+
+@app.cell
+def _(layered_wrapped):
+    layered_wrapped
+    return
+
+
+@app.cell
+def _(mo):
+    freq = mo.ui.slider(0.5, 3.0, value=1.0, step=0.1, label="Frequency")
+    freq
+    return (freq,)
+
+
+@app.cell
+def _(alt, freq, layered_widget, np, pd):
+    _x = np.linspace(0, 4 * np.pi, 80)
+    _df_sin = pd.DataFrame({"x": _x, "y": np.sin(freq.value * _x)})
+    _df_cos = pd.DataFrame({"x": _x, "y": np.cos(freq.value * _x)})
+
+    _c1 = (
+        alt.Chart(_df_sin)
+        .mark_line(color="red")
+        .encode(
+            x=alt.X("x:Q", scale=alt.Scale(domain=[0, 4 * np.pi])),
+            y=alt.Y("y:Q", scale=alt.Scale(domain=[-1.5, 1.5])),
+        )
+    )
+    _c2 = (
+        alt.Chart(_df_cos)
+        .mark_line(color="blue")
+        .encode(
+            x=alt.X("x:Q", scale=alt.Scale(domain=[0, 4 * np.pi])),
+            y=alt.Y("y:Q", scale=alt.Scale(domain=[-1.5, 1.5])),
+        )
+    )
+
+    layered_widget.chart = (_c1 + _c2).properties(width=500, height=400)
     return
 
 

--- a/tests/test_altair_widget.py
+++ b/tests/test_altair_widget.py
@@ -89,7 +89,12 @@ def test_custom_dimensions():
 
 
 def test_layered_chart_spec_preserved():
-    """Layered chart specs should pass through with datasets intact."""
+    """Layered chart specs should preserve datasets and layer data refs.
+
+    This validates the Python-side spec shape only. The JS-side fix
+    (prepareSpec handling multiple datasets) must be verified in a browser
+    via ``marimo edit demos/altairwidget.py``.
+    """
     alt = pytest.importorskip("altair")
     pd = pytest.importorskip("pandas")
     from wigglystuff.altair_widget import AltairWidget

--- a/tests/test_altair_widget.py
+++ b/tests/test_altair_widget.py
@@ -86,3 +86,65 @@ def test_custom_dimensions():
     widget = AltairWidget(width=800, height=500)
     assert widget.width == 800
     assert widget.height == 500
+
+
+def test_layered_chart_spec_preserved():
+    """Layered chart specs should pass through with datasets intact."""
+    alt = pytest.importorskip("altair")
+    pd = pytest.importorskip("pandas")
+    from wigglystuff.altair_widget import AltairWidget
+
+    df1 = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    df2 = pd.DataFrame({"x": [1, 2, 3], "y": [6, 5, 4]})
+
+    chart = alt.layer(
+        alt.Chart(df1).mark_point().encode(x="x:Q", y="y:Q"),
+        alt.Chart(df2).mark_line().encode(x="x:Q", y="y:Q"),
+    )
+    widget = AltairWidget(chart)
+
+    assert "layer" in widget.spec
+    assert "datasets" in widget.spec
+    assert len(widget.spec["layer"]) == 2
+    assert len(widget.spec["datasets"]) == 2
+
+    for layer_spec in widget.spec["layer"]:
+        assert "data" in layer_spec
+        assert "name" in layer_spec["data"]
+        assert layer_spec["data"]["name"] in widget.spec["datasets"]
+
+
+def test_hconcat_chart_spec_preserved():
+    """Concatenated chart specs should pass through with datasets intact."""
+    alt = pytest.importorskip("altair")
+    pd = pytest.importorskip("pandas")
+    from wigglystuff.altair_widget import AltairWidget
+
+    df1 = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    df2 = pd.DataFrame({"a": [5, 6], "b": [7, 8]})
+
+    chart = alt.hconcat(
+        alt.Chart(df1).mark_point().encode(x="x:Q", y="y:Q"),
+        alt.Chart(df2).mark_bar().encode(x="a:Q", y="b:Q"),
+    )
+    widget = AltairWidget(chart)
+
+    assert "hconcat" in widget.spec
+    assert "datasets" in widget.spec
+    assert len(widget.spec["datasets"]) == 2
+
+
+def test_single_chart_with_datasets():
+    """A single Altair chart still produces a datasets dict; verify it passes through."""
+    alt = pytest.importorskip("altair")
+    pd = pytest.importorskip("pandas")
+    from wigglystuff.altair_widget import AltairWidget
+
+    df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    chart = alt.Chart(df).mark_point().encode(x="x:Q", y="y:Q")
+    widget = AltairWidget(chart)
+
+    assert "datasets" in widget.spec
+    assert len(widget.spec["datasets"]) == 1
+    assert "data" in widget.spec
+    assert widget.spec["data"]["name"] in widget.spec["datasets"]

--- a/wigglystuff/static/altair-widget.js
+++ b/wigglystuff/static/altair-widget.js
@@ -28,34 +28,37 @@ async function loadVega() {
 }
 
 /**
- * Separate an Altair spec into a data-free spec and a data array.
+ * Separate an Altair spec into a data-free spec and a map of named datasets.
  *
  * Altair specs carry data in one of two shapes:
- *   a) spec.datasets = {"data-<hash>": [...]}  +  spec.data.name = "data-<hash>"
+ *   a) spec.datasets = {"data-<hash>": [...], ...}  with data.name refs in
+ *      the top level or inside layer/hconcat/vconcat sub-specs
  *   b) spec.data.values = [...]
  *
- * We replace the data reference with {name: DATA_NAME} so that the
- * compiled Vega view exposes a predictable dataset we can target with
- * view.change().
+ * For (a) we extract every dataset into dataMap keyed by its original name,
+ * replace each dataset's array with [] in the clean spec (so Vega-Lite still
+ * compiles the named sources), and leave all data.name references untouched.
+ *
+ * For (b) we extract the values into dataMap[DATA_NAME] and set
+ * clean.data = {name: DATA_NAME}.
+ *
+ * Returns {cleanSpec, dataMap} where dataMap is {name: rows[]}.
  */
 function prepareSpec(spec) {
   const clean = JSON.parse(JSON.stringify(spec));
-  let data = null;
+  const dataMap = {};
 
   if (clean.datasets) {
-    const keys = Object.keys(clean.datasets);
-    if (keys.length > 0) {
-      data = clean.datasets[keys[0]];
+    for (const [name, rows] of Object.entries(clean.datasets)) {
+      dataMap[name] = rows;
+      clean.datasets[name] = [];
     }
-    delete clean.datasets;
+  } else if (clean.data && clean.data.values) {
+    dataMap[DATA_NAME] = clean.data.values;
+    clean.data = { name: DATA_NAME };
   }
 
-  if (clean.data && clean.data.values) {
-    data = data || clean.data.values;
-  }
-
-  clean.data = { name: DATA_NAME };
-  return { cleanSpec: clean, data: data || [] };
+  return { cleanSpec: clean, dataMap };
 }
 
 /**
@@ -80,7 +83,7 @@ function render({ model, el }) {
     container.style.minHeight = model.get("height") + "px";
   }
 
-  async function fullEmbed(cleanSpec, data) {
+  async function fullEmbed(cleanSpec, dataMap) {
     if (currentView) {
       currentView.finalize();
       currentView = null;
@@ -98,9 +101,11 @@ function render({ model, el }) {
       currentView = result.view;
       currentCleanSpec = cleanSpec;
 
-      // Push data into the named source
-      const cs = vega.changeset().insert(data);
-      currentView.change(DATA_NAME, cs).run();
+      // Push data into every named source
+      for (const [name, rows] of Object.entries(dataMap)) {
+        currentView.change(name, vega.changeset().insert(rows));
+      }
+      currentView.run();
     } catch (err) {
       container.textContent = "Vega-Lite render error: " + err.message;
     }
@@ -118,21 +123,23 @@ function render({ model, el }) {
       return;
     }
 
-    const { cleanSpec, data } = prepareSpec(rawSpec);
+    const { cleanSpec, dataMap } = prepareSpec(rawSpec);
 
     // First render — or structural change
     if (!currentView || !currentCleanSpec || !specStructureEqual(currentCleanSpec, cleanSpec)) {
-      await fullEmbed(cleanSpec, data);
+      await fullEmbed(cleanSpec, dataMap);
       return;
     }
 
     // Data-only change — patch in-place, never re-parse
     const { vega } = await loadVega();
-    const cs = vega
-      .changeset()
-      .remove(() => true)
-      .insert(data);
-    currentView.change(DATA_NAME, cs).run();
+    for (const [name, rows] of Object.entries(dataMap)) {
+      currentView.change(
+        name,
+        vega.changeset().remove(() => true).insert(rows)
+      );
+    }
+    currentView.run();
   }
 
   applySize();


### PR DESCRIPTION
## Summary
Fixes #138 by replacing the single data array with a dataMap object that preserves all named dataset references. This allows layered, concatenated, and multi-dataset Altair specs to render correctly.

## Changes
- `prepareSpec()` now extracts every dataset into dataMap and keeps datasets keys with empty arrays in the clean spec
- `fullEmbed()` and `handleSpecChange()` iterate over all dataMap entries to apply changesets to each named source
- Maintains flicker-free optimization for all spec shapes

## Tests
Added three new tests for layered charts, hconcat charts, and single-dataset regression.