### PR TITLE
Add redraw() method to SplineDraw widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - New `SplineDraw` widget for drawing scatter points with a Python-computed spline curve overlay. Accepts any callable with signature `(x, y) -> (x_curve, y_curve)` for flexible curve fitting (e.g. scikit-learn pipelines, interpolation functions). Built on the same D3/SVG canvas as `ScatterWidget`.
+- `SplineDraw.redraw()` method to retrigger spline recomputation or swap in a new `spline_fn` at runtime.
 
 ### Added
 - New `ApiDoc` widget for rendering Python class and function API documentation directly in notebooks. Introspects signatures, parameters, docstrings, methods, and properties via stdlib `inspect`. Features collapsible method/property sections, colored badges for class/function/classmethod/staticmethod/property, Python syntax highlighting in fenced code blocks, inline markdown (`**bold**`, `` `code` ``), copy-to-clipboard on code examples, and light/dark theme support.

--- a/demos/splinedraw.py
+++ b/demos/splinedraw.py
@@ -70,6 +70,60 @@ def _(mo, np, pipe, sklearn_widget):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
+    ## Swapping the spline function with `redraw()`
+
+    Use `widget.redraw()` to recompute the curve when external state changes,
+    or pass a new callable to swap the fitting function entirely.
+    """)
+    return
+
+
+@app.cell
+def _(np):
+    from sklearn.kernel_ridge import KernelRidge as _KR
+
+    def make_kernel_fn(gamma):
+        def fn(x, y):
+            kr = _KR(kernel="rbf", gamma=gamma)
+            kr.fit(x.reshape(-1, 1), y)
+            x_curve = np.linspace(x.min(), x.max(), 200)
+            return x_curve, kr.predict(x_curve.reshape(-1, 1))
+        return fn
+
+    return (make_kernel_fn,)
+
+
+@app.cell
+def _(mo):
+    gamma_slider = mo.ui.slider(
+        start=-6, stop=0, step=0.5, value=-4, label="log10(gamma)"
+    )
+    return (gamma_slider,)
+
+
+@app.cell
+def _(SplineDraw, make_kernel_fn, mo):
+    redraw_widget = mo.ui.anywidget(
+        SplineDraw(spline_fn=make_kernel_fn(10 ** (-4)))
+    )
+    return (redraw_widget,)
+
+
+@app.cell
+def _(gamma_slider, mo, redraw_widget):
+    mo.vstack([gamma_slider, redraw_widget])
+    return
+
+
+@app.cell
+def _(gamma_slider, make_kernel_fn, redraw_widget):
+    redraw_widget.widget.redraw(spline_fn=make_kernel_fn(10 ** gamma_slider.value))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
     ## Multiple Classes
 
     With `n_classes > 1`, each class gets its own independent spline curve

--- a/wigglystuff/spline_draw.py
+++ b/wigglystuff/spline_draw.py
@@ -95,6 +95,22 @@ class SplineDraw(anywidget.AnyWidget):
             raise traitlets.TraitError("n_classes must be between 1 and 4")
         return value
 
+    def redraw(self, spline_fn: Callable | None = None) -> None:
+        """Recompute the spline curve, optionally with a new function.
+
+        Call this when external state affecting ``spline_fn`` has changed
+        (e.g. model hyperparameters controlled by another widget), or pass
+        a new callable to replace the fitting function entirely.
+
+        Args:
+            spline_fn: If provided, replaces the current spline function
+                before recomputing.  Must have the same
+                ``(x, y) -> (x_curve, y_curve)`` signature.
+        """
+        if spline_fn is not None:
+            self._spline_fn = spline_fn
+        self._recompute_curve()
+
     def _recompute_curve(self, change: Any = None) -> None:
         """Call spline_fn per class on current data and update the curve traitlet."""
         if len(self.data) < 2:


### PR DESCRIPTION
## Summary
Expose a public `redraw()` method that allows users to retrigger spline recomputation when external state changes (e.g., hyperparameters controlled by another widget), or pass a new `spline_fn` to swap the fitting function entirely.

## Test plan
- Smoke-tested widget instantiation and `redraw()` with and without new function argument
- Verified demo notebook structure with `marimo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)