### PR TITLE
Add Plausible analytics to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ docs_dir: mkdocs
 site_dir: site
 theme:
   name: material
+  custom_dir: mkdocs/overrides
   logo: assets/logo.png
   favicon: assets/logo.png
   icon:

--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.io/js/pa-oJ2OItBA-IjJp4EDK88ZJ.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>
+{% endblock %}

--- a/uv.lock
+++ b/uv.lock
@@ -4035,7 +4035,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.32"
+version = "0.2.33"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary

Adds privacy-friendly Plausible analytics to the docs site by creating a template override for mkdocs-material that injects the tracking script into the page head.

## Changes

- Create `mkdocs/overrides/main.html` with Plausible script injection in the `extrahead` block
- Update `mkdocs.yml` to use the custom template directory

This allows tracking of documentation site visits and user behavior while maintaining privacy standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)