### PR TITLE
Fix README gallery table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ uv pip install wigglystuff
 <td align="center"><b>DiffViewer</b><br><a href="https://koaning.github.io/wigglystuff/examples/diffviewer/"><img src="./mkdocs/assets/gallery/diffviewer.png" width="330"></a><br><a href="https://koaning.github.io/wigglystuff/examples/diffviewer/">Demo</a> · <a href="https://koaning.github.io/wigglystuff/reference/diff-viewer/">API</a> · <a href="https://koaning.github.io/wigglystuff/reference/diff-viewer.md">MD</a></td>
 <td align="center"><b>SplineDraw</b><br><a href="https://koaning.github.io/wigglystuff/examples/splinedraw/"><img src="./mkdocs/assets/gallery/splinedraw.png" width="330"></a><br><a href="https://koaning.github.io/wigglystuff/examples/splinedraw/">Demo</a> · <a href="https://koaning.github.io/wigglystuff/reference/spline-draw/">API</a> · <a href="https://koaning.github.io/wigglystuff/reference/spline-draw.md">MD</a></td>
 <td align="center"><b>ApiDoc</b><br><a href="https://koaning.github.io/wigglystuff/examples/apidoc/"><img src="./mkdocs/assets/gallery/apidoc.png" width="330"></a><br><a href="https://koaning.github.io/wigglystuff/examples/apidoc/">Demo</a> · <a href="https://koaning.github.io/wigglystuff/reference/api-doc/">API</a> · <a href="https://koaning.github.io/wigglystuff/reference/api-doc.md">MD</a></td>
+</tr>
+<tr>
 <td align="center"><b>ParallelCoordinates</b><br><a href="https://koaning.github.io/wigglystuff/examples/parallelcoords/"><img src="./mkdocs/assets/gallery/parallelcoords.png" width="330"></a><br><a href="https://koaning.github.io/wigglystuff/examples/parallelcoords/">Demo</a> · <a href="https://koaning.github.io/wigglystuff/reference/parallel-coords/">API</a> · <a href="https://koaning.github.io/wigglystuff/reference/parallel-coords.md">MD</a></td>
 </tr>
 </table>


### PR DESCRIPTION
Fixes the gallery table in the README where the last row had 4 cells instead of 3, causing the ApiDoc cell to be squished. Moves ParallelCoordinates to a new row to maintain consistent 3-column formatting.

## Changes
- Move ParallelCoordinates to a new table row
- Ensure all gallery rows maintain 3 columns maximum