### PR TITLE
Add ignore param to ParallelCoordinates and fix docs

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,3 +1,9 @@
+# Setup
+
+This repo uses a `conductor.json` setup script (`make install`) that runs
+automatically when a Conductor workspace is created. It installs all
+dependencies so the environment is ready to use immediately.
+
 # Agents
 
 `wigglystuff` ships a small roster of AnyWidget "agents" that surface different

--- a/mkdocs/reference/parallel-coords.md
+++ b/mkdocs/reference/parallel-coords.md
@@ -9,5 +9,6 @@
 | `data` | `list[dict]` | Input rows rendered as polylines. |
 | `color_by` | `str` | Column used for line coloring. |
 | `height` | `int` | Plot height in pixels. |
+| `width` | `int` | Plot width in pixels. Set to 0 for container width. |
 | `filtered_indices` | `list[int]` | Indices currently passing filters/selection. |
 | `selected_indices` | `list[int]` | Indices currently selected in the active brush. |

--- a/uv.lock
+++ b/uv.lock
@@ -4035,7 +4035,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.35"
+version = "0.2.36"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/parallel_coords.py
+++ b/wigglystuff/parallel_coords.py
@@ -23,6 +23,7 @@ class ParallelCoordinates(anywidget.AnyWidget):
             default color.
         height: Widget height in pixels.
         width: Widget width in pixels. Set to 0 for container width.
+        ignore: Column names to exclude from the plot.
 
     Examples:
         ```python
@@ -58,6 +59,7 @@ class ParallelCoordinates(anywidget.AnyWidget):
         color_by: str = "",
         height: int = 600,
         width: int = 0,
+        ignore: list[str] | None = None,
     ) -> None:
         """Create a ParallelCoordinates widget.
 
@@ -68,8 +70,14 @@ class ParallelCoordinates(anywidget.AnyWidget):
                 color.
             height: Widget height in pixels.
             width: Widget width in pixels. Set to 0 for container width.
+            ignore: Column names to exclude from the plot.
         """
         records = _to_records(data)
+        if ignore:
+            records = [
+                {k: v for k, v in row.items() if k not in ignore}
+                for row in records
+            ]
         filtered_indices = list(range(len(records)))
         super().__init__(
             data=records,


### PR DESCRIPTION
## Summary

- Added `ignore` constructor parameter to ParallelCoordinates to exclude columns from the plot
- Documented the missing `width` traitlet in the reference page
- Added setup section to CLAUDE.md explaining the conductor.json workflow

All changes tested via smoke-tests. Includes uv.lock version bump to 0.2.36.

🤖 Generated with Claude Code