### PR TITLE
Fix ParallelCoordinates axis label positioning

### DIFF
--- a/js/parallel-coords/styles.css
+++ b/js/parallel-coords/styles.css
@@ -164,13 +164,14 @@
     border-radius: 4px;
     color: var(--pc-text) !important;
     display: inline-block;
+    font-size: 11px !important;
     margin-top: -14px;
-    padding: 1px 6px;
+    padding: 1px 6px 3px;
     position: relative;
     rotate: 0deg !important;
     text-shadow: none !important;
-    top: -4px;
-    transform: none !important;
+    top: -18px;
+    transform: translateX(-50%) !important;
     transform-origin: center center !important;
     z-index: 8;
 }

--- a/wigglystuff/static/parallel-coords.css
+++ b/wigglystuff/static/parallel-coords.css
@@ -164,13 +164,14 @@
     border-radius: 4px;
     color: var(--pc-text) !important;
     display: inline-block;
+    font-size: 11px !important;
     margin-top: -14px;
-    padding: 1px 6px;
+    padding: 1px 6px 3px;
     position: relative;
     rotate: 0deg !important;
     text-shadow: none !important;
-    top: -4px;
-    transform: none !important;
+    top: -18px;
+    transform: translateX(-50%) !important;
     transform-origin: center center !important;
     z-index: 8;
 }


### PR DESCRIPTION
## Summary
Fixed axis label styling in ParallelCoordinates widget:
- Center labels horizontally with proper CSS transform
- Reduce font size to 11px for better visual hierarchy
- Move labels above axis lines to prevent overlapping
- Add extra bottom padding for visual breathing room

🤖 Generated with [Claude Code](https://claude.com/claude-code)