### PR TITLE
Use AltairWidget in forecast_chart demo for flicker-free updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.39] - 2026-03-17
+
 ### Changed
 - `forecast_chart` demo now uses `AltairWidget` for flicker-free updates in marimo wasm mode.
+
+### Fixed
+- `AltairWidget` now embeds the full spec (with data) on initial render, fixing blank charts for layered specs with named datasets.
 
 ## [0.2.38] - 2026-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `forecast_chart` demo now uses `AltairWidget` for flicker-free updates in marimo wasm mode.
+
 ## [0.2.38] - 2026-03-17
 
 ### Added

--- a/demos/forecast_chart.py
+++ b/demos/forecast_chart.py
@@ -12,7 +12,7 @@
 
 import marimo
 
-
+__generated_with = "0.21.0"
 app = marimo.App(width="medium")
 
 
@@ -33,9 +33,9 @@ def _():
 
 @app.cell
 def _():
-    from wigglystuff import forecast_chart
+    from wigglystuff import AltairWidget, forecast_chart
 
-    return (forecast_chart,)
+    return AltairWidget, forecast_chart
 
 
 @app.cell(hide_code=True)
@@ -85,20 +85,74 @@ def _(np, pl):
 
 
 @app.cell
+def _(AltairWidget):
+    widget = AltairWidget(width=600, height=400)
+    return (widget,)
+
+
+@app.cell
+def _(mo, widget):
+    wrapped = mo.ui.anywidget(widget)
+    return (wrapped,)
+
+
+@app.cell
 def _(fit_window, mo, projection_days):
     mo.hstack([fit_window, projection_days])
     return
 
 
 @app.cell(hide_code=True)
-def _(df, fit_window, forecast_chart, projection_days):
-    forecast_chart(
+def _(df, fit_window, forecast_chart, projection_days, widget):
+    import time
+
+    time.sleep(0.1)
+
+    widget.chart = forecast_chart(
         df,
         date_col="date",
         value_col="value",
         fit_window=fit_window.value,
         projection_days=projection_days.value,
         title="Synthetic metric forecast",
+        width=600,
+    )
+    return (time,)
+
+
+@app.cell
+def _(wrapped):
+    wrapped
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    The chart above is wrapped in an `AltairWidget` via `mo.ui.anywidget`.
+    This keeps the DOM element stable across slider changes so the Vega view
+    can patch data in-place instead of rebuilding from scratch. The result is
+    a flicker-free experience, especially in marimo's WASM mode where full
+    re-renders cause noticeable jumps.
+
+    For comparison, the plain `forecast_chart` output is shown below. Try
+    dragging the sliders and notice the difference.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(df, fit_window, forecast_chart, projection_days, time):
+    time.sleep(0.1)
+
+    forecast_chart(
+        df,
+        date_col="date",
+        value_col="value",
+        fit_window=fit_window.value,
+        projection_days=projection_days.value,
+        title="Synthetic metric forecast (plain)",
+        width=600,
     )
     return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.38"
+version = "0.2.39"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wigglystuff/static/altair-widget.js
+++ b/wigglystuff/static/altair-widget.js
@@ -83,7 +83,7 @@ function render({ model, el }) {
     container.style.minHeight = model.get("height") + "px";
   }
 
-  async function fullEmbed(cleanSpec, dataMap) {
+  async function fullEmbed(rawSpec, cleanSpec) {
     if (currentView) {
       currentView.finalize();
       currentView = null;
@@ -91,21 +91,18 @@ function render({ model, el }) {
     container.innerHTML = "";
     currentCleanSpec = null;
 
-    const { vegaEmbed, vega } = await loadVega();
+    const { vegaEmbed } = await loadVega();
 
     try {
-      const result = await vegaEmbed(container, cleanSpec, {
+      // Embed the full spec (with data) so the initial render is always
+      // correct.  We store the data-free cleanSpec for future comparisons
+      // so that subsequent data-only changes can be patched in-place.
+      const result = await vegaEmbed(container, rawSpec, {
         actions: false,
         renderer: "svg",
       });
       currentView = result.view;
       currentCleanSpec = cleanSpec;
-
-      // Push data into every named source
-      for (const [name, rows] of Object.entries(dataMap)) {
-        currentView.change(name, vega.changeset().insert(rows));
-      }
-      currentView.run();
     } catch (err) {
       container.textContent = "Vega-Lite render error: " + err.message;
     }
@@ -125,9 +122,9 @@ function render({ model, el }) {
 
     const { cleanSpec, dataMap } = prepareSpec(rawSpec);
 
-    // First render — or structural change
+    // First render — or structural change: embed the full spec with data
     if (!currentView || !currentCleanSpec || !specStructureEqual(currentCleanSpec, cleanSpec)) {
-      await fullEmbed(cleanSpec, dataMap);
+      await fullEmbed(rawSpec, cleanSpec);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Restructured forecast_chart demo to use AltairWidget for flicker-free slider interactions in marimo WASM mode
- Fixed AltairWidget initial rendering bug: now embeds full spec (with data) instead of empty spec with attempted changeset insertion
- Added explanatory markdown and plain comparison chart to demonstrate the difference

## Details
AltairWidget keeps the DOM element stable while the Vega view patches data in-place. The demo now follows this pattern: create persistent widget → wrap with anywidget → assign chart on slider change. This eliminates visual jumps when fit_window or projection_days sliders move.

The JS fix ensures the initial render is always correct by embedding the full spec with data, while preserving the efficient changeset path for subsequent data-only updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)