### PR TITLE
Prevent axis text selection in ParallelCoordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - `ParallelCoordinates` now exposes a `selections` property that returns the full filtering state: completed Keep/Exclude steps plus the active brush, enabling decision-tree-style filtering audit trails.
 - `ParallelCoordinates` now has `keep()`, `exclude()`, and `restore()` methods for programmatic control from Python.
 
+### Fixed
+- `ParallelCoordinates` axis tick labels no longer get highlighted during brush/drag interactions.
+
 ## [0.2.39] - 2026-03-17
 
 ### Changed

--- a/js/parallel-coords/styles.css
+++ b/js/parallel-coords/styles.css
@@ -6,6 +6,8 @@
 
 .pc-wrapper {
     color-scheme: light dark;
+    -webkit-user-select: none;
+    user-select: none;
     --pc-bg: #ffffff;
     --pc-border: #d0d7de;
     --pc-text: #111827;

--- a/wigglystuff/static/parallel-coords.css
+++ b/wigglystuff/static/parallel-coords.css
@@ -6,6 +6,8 @@
 
 .pc-wrapper {
     color-scheme: light dark;
+    -webkit-user-select: none;
+    user-select: none;
     --pc-bg: #ffffff;
     --pc-border: #d0d7de;
     --pc-text: #111827;


### PR DESCRIPTION
## Summary
Added `user-select: none` to the `.pc-wrapper` root in the ParallelCoordinates widget to prevent axis tick labels from being highlighted during brush/drag interactions.

## Changes
- Updated `js/parallel-coords/styles.css` to add `user-select: none` with vendor prefixes
- Synced change to compiled `wigglystuff/static/parallel-coords.css`
- Updated changelog under `[Unreleased]`

This fixes the visual issue where axis numbers would be selected text when users interact with the widget.