### PR TITLE
Fix PlaySlider precision and add values property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.40] - 2026-03-24
+
 ### Added
+- `PlaySlider` now has a `values` property that returns all discrete values in the range, useful for pre-caching downstream results before hitting play.
 - `ParallelCoordinates` now exposes a `selections` property that returns the full filtering state: completed Keep/Exclude steps plus the active brush, enabling decision-tree-style filtering audit trails.
 - `ParallelCoordinates` now has `keep()`, `exclude()`, and `restore()` methods for programmatic control from Python.
 
 ### Fixed
+- `PlaySlider` no longer produces floating-point rounding artifacts (e.g., `0.30000000000000004`) when using fractional step values. Both the displayed label and the synced Python value are now rounded to the step's precision.
 - `ParallelCoordinates` axis tick labels no longer get highlighted during brush/drag interactions.
 
 ## [0.2.39] - 2026-03-17

--- a/demos/play_slider.py
+++ b/demos/play_slider.py
@@ -4,7 +4,7 @@
 #     "marimo",
 #     "matplotlib",
 #     "numpy",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.2.40",
 # ]
 # ///
 import marimo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.2.39"
+version = "0.2.40"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -4153,7 +4153,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.2.39"
+version = "0.2.40"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/play_slider.py
+++ b/wigglystuff/play_slider.py
@@ -68,3 +68,15 @@ class PlaySlider(anywidget.AnyWidget):
             width=width,
             **kwargs,
         )
+
+    @property
+    def values(self):
+        """All discrete values from min_value to max_value (inclusive) at the current step."""
+        step_str = str(self.step)
+        precision = len(step_str.rstrip("0").split(".")[-1]) if "." in step_str else 0
+        result = []
+        v = self.min_value
+        while v <= self.max_value:
+            result.append(round(v, precision))
+            v += self.step
+        return result

--- a/wigglystuff/static/play-slider.js
+++ b/wigglystuff/static/play-slider.js
@@ -49,7 +49,7 @@ function render({ model, el }) {
   function renderValue() {
     const val = model.get("value");
     slider.value = val;
-    label.textContent = val;
+    label.textContent = val.toFixed(getPrecision());
     updateTrackFill();
   }
 
@@ -57,10 +57,18 @@ function render({ model, el }) {
     btn.innerHTML = model.get("playing") ? PAUSE_ICON : PLAY_ICON;
   }
 
+  function getPrecision() {
+    const s = String(model.get("step"));
+    const dot = s.indexOf(".");
+    return dot === -1 ? 0 : s.length - dot - 1;
+  }
+
   function snap(val) {
     const step = model.get("step");
     const min = model.get("min_value");
-    return Math.round((val - min) / step) * step + min;
+    const prec = getPrecision();
+    const raw = Math.round((val - min) / step) * step + min;
+    return parseFloat(raw.toFixed(prec));
   }
 
   function tick() {
@@ -117,7 +125,7 @@ function render({ model, el }) {
   // Manual slider input
   slider.addEventListener("input", () => {
     localUpdate = true;
-    model.set("value", parseFloat(slider.value));
+    model.set("value", snap(parseFloat(slider.value)));
     model.save_changes();
     updateTrackFill();
   });


### PR DESCRIPTION
## Summary
- Fix floating-point rounding artifacts in PlaySlider (e.g., `0.30000000000000004` with step=0.1) by rounding snapped values to the step's decimal precision in both JS frontend and Python backend.
- Add a `values` property that returns all discrete values in the range, so users can pre-cache downstream computations before hitting play.
- Bump version to 0.2.40 and update the demo pin from 0.2.37 to 0.2.40 (fixes MoLab loading).

## Test plan
- [ ] `uv run python -c "from wigglystuff import PlaySlider; s = PlaySlider(min_value=0, max_value=1, step=0.1); print(s.values)"` returns clean `[0.0, 0.1, ..., 1.0]`
- [ ] Open `demos/play_slider.py` in marimo, set step=0.1, confirm no rounding artifacts in label or Python value
- [ ] Verify auto-advance with loop=True produces clean values throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)