### PR TITLE
Bump demo PEP 723 version pins to 0.3.1

### DIFF
--- a/demos/altairwidget.py
+++ b/demos/altairwidget.py
@@ -5,7 +5,7 @@
 #     "marimo>=0.19.11",
 #     "numpy==2.4.2",
 #     "pandas==3.0.1",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/annotation.py
+++ b/demos/annotation.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "marimo",
 #     "mohtml",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/apidoc.py
+++ b/demos/apidoc.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo>=0.19.7",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/celltour.py
+++ b/demos/celltour.py
@@ -4,7 +4,7 @@
 #     "anywidget==0.9.21",
 #     "marimo",
 #     "numpy==2.3.5",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/chartmultiselect.py
+++ b/demos/chartmultiselect.py
@@ -5,7 +5,7 @@
 #     "matplotlib",
 #     "numpy",
 #     "scikit-learn",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/chartpuck.py
+++ b/demos/chartpuck.py
@@ -6,7 +6,7 @@
 #     "numpy",
 #     "scikit-learn",
 #     "scipy",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/chartselect.py
+++ b/demos/chartselect.py
@@ -4,7 +4,7 @@
 #     "marimo",
 #     "matplotlib",
 #     "numpy",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/colorpicker.py
+++ b/demos/colorpicker.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.14"
 # dependencies = [
 #     "marimo>=0.19.7",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/copytoclipboard.py
+++ b/demos/copytoclipboard.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/diffviewer.py
+++ b/demos/diffviewer.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/drivertour.py
+++ b/demos/drivertour.py
@@ -4,7 +4,7 @@
 #     "anywidget==0.9.21",
 #     "marimo",
 #     "numpy==2.3.5",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/edgedraw.py
+++ b/demos/edgedraw.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/forecast_chart.py
+++ b/demos/forecast_chart.py
@@ -6,7 +6,7 @@
 #     "numpy==2.4.2",
 #     "polars==1.30.0",
 #     "scikit-learn==1.8.0",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/gamepad.py
+++ b/demos/gamepad.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/greedy_search_pucks.py
+++ b/demos/greedy_search_pucks.py
@@ -4,7 +4,7 @@
 #     "marimo",
 #     "numpy",
 #     "matplotlib",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/hoverzoom.py
+++ b/demos/hoverzoom.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.14"
 # dependencies = [
 #     "marimo>=0.19.7",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 #     "Pillow",
 #     "matplotlib",
 #     "numpy",

--- a/demos/htmlwidget.py
+++ b/demos/htmlwidget.py
@@ -7,7 +7,7 @@
 #     "mohtml==0.1.7",
 #     "numpy==2.2.5",
 #     "polars==1.29.0",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/keystroke.py
+++ b/demos/keystroke.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.14"
 # dependencies = [
 #     "marimo>=0.19.11",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/matrix.py
+++ b/demos/matrix.py
@@ -5,7 +5,7 @@
 #     "altair",
 #     "numpy",
 #     "pandas",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/moduletree.py
+++ b/demos/moduletree.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo>=0.19.7",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 #     "torch>=2.0",
 #     "transformers>=4.0",
 # ]

--- a/demos/neo4jwidget.py
+++ b/demos/neo4jwidget.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "marimo>=0.19.7",
 #     "neo4j>=5.0.0",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/paint.py
+++ b/demos/paint.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "marimo",
 #     "mohtml",
-#     "wigglystuff==0.2.40",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/parallelcoords.py
+++ b/demos/parallelcoords.py
@@ -5,7 +5,7 @@
 #     "numpy",
 #     "polars",
 #     "scikit-learn",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/play_slider.py
+++ b/demos/play_slider.py
@@ -4,7 +4,7 @@
 #     "marimo",
 #     "matplotlib",
 #     "numpy",
-#     "wigglystuff==0.2.40",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/pulsarchart.py
+++ b/demos/pulsarchart.py
@@ -5,7 +5,7 @@
 #     "matplotlib==3.10.8",
 #     "numpy==2.4.0",
 #     "pandas==2.3.3",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/scatterwidget.py
+++ b/demos/scatterwidget.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/shortcut.py
+++ b/demos/shortcut.py
@@ -8,7 +8,7 @@
 #     "mohtml==0.1.7",
 #     "numpy==2.2.5",
 #     "polars==1.29.0",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/slider2d.py
+++ b/demos/slider2d.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/sortlist.py
+++ b/demos/sortlist.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/splinedraw.py
+++ b/demos/splinedraw.py
@@ -5,7 +5,7 @@
 #     "matplotlib",
 #     "numpy",
 #     "scikit-learn",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/talk.py
+++ b/demos/talk.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/tangle.py
+++ b/demos/tangle.py
@@ -5,7 +5,7 @@
 #     "marimo>=0.19.4",
 #     "numpy==2.4.1",
 #     "pandas==2.3.3",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 

--- a/demos/textcompare.py
+++ b/demos/textcompare.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/threewidget.py
+++ b/demos/threewidget.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo

--- a/demos/webcam_capture.py
+++ b/demos/webcam_capture.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "marimo",
 #     "mohtml",
-#     "wigglystuff==0.2.37",
+#     "wigglystuff==0.3.1",
 # ]
 # ///
 import marimo


### PR DESCRIPTION
## Summary
- All 35 demo notebooks had stale PEP 723 version pins (`wigglystuff==0.2.37` or `0.2.40`)
- This caused `ImportError` when running `uv run demos/forecast_chart.py` because `forecast_chart` was added in 0.2.38
- Bumps all demos to `wigglystuff==0.3.1` (current release)

## Test plan
- [x] `uv run python -c "from wigglystuff import forecast_chart"` passes
- [x] `uv run marimo check demos/forecast_chart.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)