### PR TITLE
Default forecast_chart width to container for responsive sizing

### DIFF
--- a/demos/forecast_chart.py
+++ b/demos/forecast_chart.py
@@ -86,7 +86,7 @@ def _(np, pl):
 
 @app.cell
 def _(AltairWidget):
-    widget = AltairWidget(width=600, height=400)
+    widget = AltairWidget(height=400)
     return (widget,)
 
 
@@ -115,7 +115,6 @@ def _(df, fit_window, forecast_chart, projection_days, widget):
         fit_window=fit_window.value,
         projection_days=projection_days.value,
         title="Synthetic metric forecast",
-        width=600,
     )
     return (time,)
 
@@ -152,7 +151,6 @@ def _(df, fit_window, forecast_chart, projection_days, time):
         fit_window=fit_window.value,
         projection_days=projection_days.value,
         title="Synthetic metric forecast (plain)",
-        width=600,
     )
     return
 

--- a/wigglystuff/utils.py
+++ b/wigglystuff/utils.py
@@ -108,7 +108,7 @@ def forecast_chart(
     fit_window: int = 180,
     projection_days: int = 365,
     title: str | None = None,
-    width: int | None = None,
+    width: int | str | None = None,
     height: int = 400,
 ):
     """Create a time series chart with an exponential forecast.
@@ -123,7 +123,7 @@ def forecast_chart(
         fit_window: Number of most-recent data points to use for the fit.
         projection_days: How many days to project into the future.
         title: Optional chart title.
-        width: Chart width in pixels. If None, uses Altair default.
+        width: Chart width in pixels, or "container" for responsive. Defaults to "container".
         height: Chart height in pixels (default 400).
 
     Returns:
@@ -229,10 +229,9 @@ def forecast_chart(
 
     props = {
         "height": height,
+        "width": width if width is not None else "container",
         "usermeta": {"embedOptions": {"actions": False}},
     }
-    if width is not None:
-        props["width"] = width
     if title:
         props["title"] = title
 


### PR DESCRIPTION
## Summary
- `forecast_chart()` now defaults to `width="container"` instead of omitting width, so charts fill their container in marimo.
- Accepts `int | str | None` for the `width` parameter to support both pixel values and Altair string options.
- Removes hardcoded `width=600` from the demo notebook.

## Test plan
- [x] Smoke-tested default returns `"container"`, explicit pixel width still works
- [x] `marimo check` and `uv run demos/forecast_chart.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)