### PR TITLE
Add ApiDoc syntax-highlighted signature and Markdown export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-04-10
+
+### Added
+- `ApiDoc.to_markdown()` method to export API documentation as a Markdown string for use in READMEs.
+- `ApiDoc` signature block now has Python syntax highlighting, matching code blocks in docstrings.
+
 ### Changed
 - Moved example notebooks from `examples/` to `demos/` folder.
 - Added infinite zoom (Droste effect) example to the docs gallery.

--- a/demos/apidoc.py
+++ b/demos/apidoc.py
@@ -8,7 +8,7 @@
 
 import marimo
 
-__generated_with = "0.20.2"
+__generated_with = "0.23.0"
 app = marimo.App(width="medium")
 
 
@@ -108,6 +108,22 @@ class Estimator:
 @app.cell
 def _(ApiDoc, mo):
     mo.ui.anywidget(ApiDoc(Estimator))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Markdown export
+
+    You can export the documentation as Markdown with `to_markdown()`, handy for GitHub READMEs.
+    """)
+    return
+
+
+@app.cell
+def _(ApiDoc):
+    print(ApiDoc(Estimator).to_markdown())
     return
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.3.1"
+version = "0.3.2"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wigglystuff/api_doc.py
+++ b/wigglystuff/api_doc.py
@@ -178,6 +178,65 @@ class ApiDoc(anywidget.AnyWidget):
         if obj is not None:
             self.doc = _extract_doc(obj, show_private)
 
+    def to_markdown(self) -> str:
+        """Export the API documentation as a Markdown string."""
+        doc = self.doc
+        if not doc or not doc.get("name"):
+            return ""
+
+        parts = []
+
+        # Title
+        prefix = f"{doc['module']}." if doc.get("module") else ""
+        parts.append(f"## `{prefix}{doc['name']}`")
+        parts.append(f"\n> {doc.get('kind', 'class')}")
+
+        # Signature
+        if doc.get("signature"):
+            parts.append(f"\n```python\n{doc['name']}{doc['signature']}\n```")
+
+        # Bases
+        if doc.get("bases"):
+            bases = ", ".join(f"`{b}`" for b in doc["bases"])
+            parts.append(f"\nBases: {bases}")
+
+        # Docstring
+        if doc.get("docstring"):
+            parts.append(f"\n{doc['docstring']}")
+
+        # Parameter table
+        params = doc.get("parameters", [])
+        if params:
+            parts.append("\n| Name | Type | Default |")
+            parts.append("| --- | --- | --- |")
+            for p in params:
+                name = f"`{p['name']}`"
+                ann = f"`{p['annotation']}`" if p.get("annotation") else ""
+                default = f"`{p['default']}`" if p.get("default") else ""
+                parts.append(f"| {name} | {ann} | {default} |")
+
+        # Methods
+        methods = doc.get("methods", [])
+        if methods:
+            parts.append("\n### Methods")
+            for m in methods:
+                sig = m.get("signature", "()")
+                decorator = f" *{m['decorator']}*" if m.get("decorator") else ""
+                parts.append(f"\n#### `{m['name']}{sig}`{decorator}")
+                if m.get("docstring"):
+                    parts.append(f"\n{m['docstring']}")
+
+        # Properties
+        props = doc.get("properties", [])
+        if props:
+            parts.append("\n### Properties")
+            for p in props:
+                parts.append(f"\n#### `{p['name']}` *property*")
+                if p.get("docstring"):
+                    parts.append(f"\n{p['docstring']}")
+
+        return "\n".join(parts)
+
     @traitlets.observe("show_private")
     def _reextract(self, change):
         if getattr(self, "_obj", None) is not None:

--- a/wigglystuff/static/api-doc.js
+++ b/wigglystuff/static/api-doc.js
@@ -374,7 +374,7 @@ function render({ model, el }) {
     if (doc.signature) {
       const sigDiv = document.createElement("div");
       sigDiv.className = "ad-signature";
-      sigDiv.textContent = doc.name + doc.signature;
+      sigDiv.innerHTML = highlightPython(doc.name + doc.signature);
       container.appendChild(sigDiv);
     }
 


### PR DESCRIPTION
## Summary
- Add Python syntax highlighting to the ApiDoc signature block, matching the existing highlighting in docstring code blocks.
- Add `ApiDoc.to_markdown()` method to export API documentation as GitHub-friendly Markdown (title, signature, parameter table, methods, properties).
- Update the `demos/apidoc.py` notebook with a cell demonstrating the Markdown export.
- Bump version to 0.3.2.

## Test plan
- [ ] Open `demos/apidoc.py` in marimo and verify the signature line has syntax coloring
- [ ] Run `ApiDoc(SomeClass).to_markdown()` and verify the output renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)