### PR TITLE
Feature: add hover tooltip support to ChartSelect

### DIFF
--- a/tests/test_chart_select.py
+++ b/tests/test_chart_select.py
@@ -27,3 +27,43 @@ def test_from_callback_allows_get_mask_during_initial_draw():
     assert widget.has_selection is False
     assert widget.selection == {}
     assert widget.get_mask(x_data, y_data).tolist() == [False, False, False]
+
+
+def test_point_data_default_empty():
+    fig, ax = plt.subplots()
+    ax.scatter([1, 2], [3, 4])
+    widget = ChartSelect(fig)
+    plt.close(fig)
+    assert widget.point_data == []
+
+
+def test_point_data_accepts_dicts():
+    fig, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+    widget = ChartSelect(fig)
+    plt.close(fig)
+
+    points = [
+        {"x": 1.0, "y": 4.0, "name": "sig_1", "category": "A"},
+        {"x": 2.0, "y": 5.0, "name": "sig_2", "category": "B"},
+        {"x": 3.0, "y": 6.0, "name": "sig_3", "category": "A"},
+    ]
+    widget.point_data = points
+    assert len(widget.point_data) == 3
+    assert widget.point_data[0]["name"] == "sig_1"
+    assert widget.point_data[1]["category"] == "B"
+
+
+def test_point_data_backward_compatible():
+    """ChartSelect works without point_data (backward compatible)."""
+    fig, ax = plt.subplots()
+    ax.scatter([1, 2], [3, 4])
+    widget = ChartSelect(fig, mode="lasso")
+    plt.close(fig)
+
+    # All existing functionality works without point_data
+    assert widget.mode == "lasso"
+    assert widget.has_selection is False
+    assert widget.point_data == []
+    mask = widget.get_mask([1, 2], [3, 4])
+    assert mask.tolist() == [False, False]

--- a/wigglystuff/chart_select.py
+++ b/wigglystuff/chart_select.py
@@ -97,6 +97,12 @@ class ChartSelect(AnyWidget):
     selection_opacity = traitlets.Float(0.3).tag(sync=True)
     stroke_width = traitlets.Int(2).tag(sync=True)
 
+    # Optional point data for hover tooltips.
+    # Each entry is a dict with "x" and "y" (data-space coordinates) plus
+    # arbitrary tooltip fields (e.g. "name", "category").
+    # When provided, hovering over the chart shows a tooltip for the nearest point.
+    point_data = traitlets.List(traitlets.Dict(), default_value=[]).tag(sync=True)
+
     def __init__(
         self,
         fig: Any,

--- a/wigglystuff/static/chart-select.css
+++ b/wigglystuff/static/chart-select.css
@@ -95,3 +95,52 @@
   border-top: 1px solid var(--cs-border);
   border-radius: 4px;
 }
+
+/* === Hover Tooltip === */
+.chart-select__tooltip {
+  display: none;
+  position: absolute;
+  pointer-events: none;
+  z-index: 10;
+  background: var(--cs-bg);
+  border: 1px solid var(--cs-border);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px var(--cs-shadow);
+  overflow: hidden;
+  min-width: 140px;
+  max-width: 300px;
+}
+
+.chart-select__tt-title {
+  padding: 5px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--cs-text);
+  background: color-mix(in srgb, var(--cs-btn-bg) 80%, transparent);
+  border-bottom: 1px solid var(--cs-border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chart-select__tt-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  padding: 3px 0;
+}
+
+.chart-select__tt-key {
+  padding: 1px 6px 1px 8px;
+  font-size: 10px;
+  color: var(--cs-text-muted);
+  white-space: nowrap;
+}
+
+.chart-select__tt-val {
+  padding: 1px 8px 1px 0;
+  font-size: 10px;
+  color: var(--cs-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/wigglystuff/static/chart-select.js
+++ b/wigglystuff/static/chart-select.js
@@ -51,7 +51,12 @@ function render({ model, el }) {
     canvas.classList.add("chart-select__canvas--no-controls");
   }
 
+  // Tooltip for point hover (only active when point_data is provided)
+  const tooltip = document.createElement("div");
+  tooltip.className = "chart-select__tooltip";
+
   container.appendChild(canvas);
+  container.appendChild(tooltip);
   el.appendChild(container);
 
   // === STATE ===
@@ -59,6 +64,7 @@ function render({ model, el }) {
   const chartImage = new Image();
   let imageLoaded = false;
   let currentMode = model.get("mode");
+  let hoveredPointIdx = -1;
 
   // Selection state
   let isSelecting = false;
@@ -133,6 +139,73 @@ function render({ model, el }) {
     return inside;
   }
 
+  // === HOVER TOOLTIP ===
+  function findNearestPoint(coords) {
+    const points = model.get("point_data") || [];
+    if (points.length === 0) return -1;
+    const threshold = 64; // squared pixel distance
+    let bestIdx = -1;
+    let bestDist = threshold;
+    for (let i = 0; i < points.length; i++) {
+      const p = dataToPixel(points[i].x, points[i].y);
+      const dx = p.x - coords.x;
+      const dy = p.y - coords.y;
+      const d2 = dx * dx + dy * dy;
+      if (d2 < bestDist) {
+        bestDist = d2;
+        bestIdx = i;
+      }
+    }
+    return bestIdx;
+  }
+
+  function esc(s) {
+    return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function showTooltip(idx, canvasCoords) {
+    const points = model.get("point_data") || [];
+    const pt = points[idx];
+    if (!pt) return;
+
+    // Build tooltip HTML from all fields except x and y
+    const keys = Object.keys(pt).filter((k) => k !== "x" && k !== "y");
+    let html = "";
+    if (keys.length > 0) {
+      // Use the first non-coordinate field as the title
+      html += `<div class="chart-select__tt-title">${esc(pt[keys[0]])}</div>`;
+      if (keys.length > 1) {
+        html += '<div class="chart-select__tt-grid">';
+        for (let i = 1; i < keys.length; i++) {
+          html += `<div class="chart-select__tt-key">${esc(keys[i])}</div>`;
+          html += `<div class="chart-select__tt-val">${esc(pt[keys[i]])}</div>`;
+        }
+        html += "</div>";
+      }
+    }
+
+    tooltip.innerHTML = html;
+    tooltip.style.display = "block";
+
+    // Position relative to the canvas display size
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = rect.width / canvas.width;
+    const scaleY = rect.height / canvas.height;
+    const px = canvasCoords.x * scaleX;
+    const py = canvasCoords.y * scaleY;
+
+    // Prefer right of cursor; flip left if near edge
+    const tipW = tooltip.offsetWidth;
+    const left = px + 16 + tipW > rect.width ? px - tipW - 8 : px + 16;
+    tooltip.style.left = left + "px";
+    tooltip.style.top = py - 12 + "px";
+  }
+
+  function hideTooltip() {
+    tooltip.style.display = "none";
+    hoveredPointIdx = -1;
+  }
+
   // === MODE MANAGEMENT ===
   function setMode(mode) {
     currentMode = mode;
@@ -181,6 +254,7 @@ function render({ model, el }) {
   // === EVENT HANDLERS ===
   function handleMouseDown(event) {
     event.preventDefault();
+    hideTooltip();
     const coords = getCanvasCoords(event);
 
     // Check if clicking inside existing selection (to drag it)
@@ -227,8 +301,21 @@ function render({ model, el }) {
     // Update cursor based on hover state
     if (model.get("has_selection") && isInsideSelection(coords)) {
       canvas.style.cursor = "move";
+      hideTooltip();
     } else {
       canvas.style.cursor = "crosshair";
+      // Show tooltip for nearest point when idle
+      if (!isSelecting) {
+        const idx = findNearestPoint(coords);
+        if (idx !== hoveredPointIdx) {
+          hoveredPointIdx = idx;
+          if (idx >= 0) {
+            showTooltip(idx, coords);
+          } else {
+            hideTooltip();
+          }
+        }
+      }
     }
 
     // Handle creating new selection


### PR DESCRIPTION
Add an optional point_data trait to ChartSelect that enables hover tooltips when the user provides point metadata. Each entry is a dict with x and y data-space coordinates plus arbitrary fields that are displayed ina styled tooltip hover.

First non-coord field is shown as a bold title, remaining fields appear in  a key-value grid.
Tooltip auto-positions to avoid overflowing the chart edge. Fully backward compatible when point_data is empty (default) behaviour is unchanegd.