### PR TITLE
Add clanker banner, dark mode toggle, and Geist font

### DIFF
--- a/mkdocs/assets/stylesheets/extra.css
+++ b/mkdocs/assets/stylesheets/extra.css
@@ -273,44 +273,44 @@
 }
 
 /* ——————————————————————————————————————————
-   LLM markdown banner (top of reference pages)
+   LLM markdown pill (top of reference pages)
    —————————————————————————————————————————— */
 .llm-md-banner {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: 0.4rem;
+  padding: 0.3rem 0.65rem;
   margin: 0 0 1.5rem;
   border: 1px solid var(--wiggly-border);
-  border-radius: 8px;
-  background: var(--wiggly-card-bg);
-  box-shadow: var(--wiggly-card-shadow);
+  border-radius: 999px;
+  background: var(--wiggly-btn-bg);
+  color: var(--md-primary-fg-color);
   text-decoration: none;
-  color: inherit;
-  font-size: 0.85rem;
-  transition: border-color 120ms ease, transform 120ms ease;
+  font-size: 0.72rem;
+  line-height: 1.3;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .llm-md-banner:hover {
-  border-color: var(--wiggly-molab);
-  transform: translateY(-1px);
+  background: var(--wiggly-btn-bg-hover);
+  border-color: var(--wiggly-border-hover);
 }
 
 .llm-md-banner__icon {
-  font-size: 1.25rem;
+  font-size: 0.85rem;
   line-height: 1;
 }
 
-.llm-md-banner__text {
-  flex: 1;
-  line-height: 1.4;
+.llm-md-banner__text strong {
+  font-weight: 700;
+  margin-right: 0.15rem;
 }
 
 .llm-md-banner__text code {
-  background: rgba(0, 0, 0, 0.05);
-  padding: 0.05rem 0.3rem;
-  border-radius: 3px;
-  font-size: 0.8rem;
+  background: rgba(0, 0, 0, 0.06);
+  padding: 0 0.25rem;
+  border-radius: 2px;
+  font-size: 0.9em;
 }
 
 [data-md-color-scheme="slate"] .llm-md-banner__text code {
@@ -320,7 +320,7 @@
 .llm-md-banner__arrow {
   color: var(--wiggly-molab);
   font-weight: 700;
-  font-size: 1.1rem;
+  margin-left: 0.15rem;
 }
 
 /* ——————————————————————————————————————————

--- a/mkdocs/assets/stylesheets/extra.css
+++ b/mkdocs/assets/stylesheets/extra.css
@@ -273,53 +273,35 @@
 }
 
 /* ——————————————————————————————————————————
-   LLM markdown pill (top of reference pages)
+   LLM markdown pill (top-right of reference pages)
    —————————————————————————————————————————— */
-.llm-md-banner {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.65rem;
-  margin: 0 0 1.5rem;
+.llm-md-link {
+  float: right;
+  margin: 0.65rem 0 0.5rem 1rem;
+  padding: 0.2rem 0.65rem;
   border: 1px solid var(--wiggly-border);
   border-radius: 999px;
-  background: var(--wiggly-btn-bg);
-  color: var(--md-primary-fg-color);
+  background: transparent;
+  color: var(--wiggly-muted);
   text-decoration: none;
-  font-size: 0.72rem;
-  line-height: 1.3;
-  transition: background-color 0.15s ease, border-color 0.15s ease;
+  font-size: 0.7rem;
+  line-height: 1.5;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
-.llm-md-banner:hover {
-  background: var(--wiggly-btn-bg-hover);
+.llm-md-link:hover {
+  color: var(--md-primary-fg-color);
   border-color: var(--wiggly-border-hover);
 }
 
-.llm-md-banner__icon {
-  font-size: 0.85rem;
-  line-height: 1;
+.llm-md-link code {
+  background: none;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
 }
 
-.llm-md-banner__text strong {
-  font-weight: 700;
-  margin-right: 0.15rem;
-}
-
-.llm-md-banner__text code {
-  background: rgba(0, 0, 0, 0.06);
-  padding: 0 0.25rem;
-  border-radius: 2px;
-  font-size: 0.9em;
-}
-
-[data-md-color-scheme="slate"] .llm-md-banner__text code {
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.llm-md-banner__arrow {
-  color: var(--wiggly-molab);
-  font-weight: 700;
+.llm-md-link__arrow {
   margin-left: 0.15rem;
 }
 

--- a/mkdocs/assets/stylesheets/extra.css
+++ b/mkdocs/assets/stylesheets/extra.css
@@ -273,6 +273,57 @@
 }
 
 /* ——————————————————————————————————————————
+   LLM markdown banner (top of reference pages)
+   —————————————————————————————————————————— */
+.llm-md-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin: 0 0 1.5rem;
+  border: 1px solid var(--wiggly-border);
+  border-radius: 8px;
+  background: var(--wiggly-card-bg);
+  box-shadow: var(--wiggly-card-shadow);
+  text-decoration: none;
+  color: inherit;
+  font-size: 0.85rem;
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.llm-md-banner:hover {
+  border-color: var(--wiggly-molab);
+  transform: translateY(-1px);
+}
+
+.llm-md-banner__icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.llm-md-banner__text {
+  flex: 1;
+  line-height: 1.4;
+}
+
+.llm-md-banner__text code {
+  background: rgba(0, 0, 0, 0.05);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}
+
+[data-md-color-scheme="slate"] .llm-md-banner__text code {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.llm-md-banner__arrow {
+  color: var(--wiggly-molab);
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+/* ——————————————————————————————————————————
    Small-screen adjustments
    —————————————————————————————————————————— */
 @media (max-width: 600px) {

--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -8,3 +8,18 @@
   plausible.init()
 </script>
 {% endblock %}
+
+{% block content %}
+  {% if page and "reference/" in page.url and page.url != "reference/" %}
+    {% set slug = page.url | replace("reference/", "") | replace("/", "") %}
+    <a class="llm-md-banner" href="../{{ slug }}.md">
+      <span class="llm-md-banner__icon">📄</span>
+      <span class="llm-md-banner__text">
+        <strong>Feeding an LLM?</strong>
+        Grab this page as raw markdown — drop the <code>.md</code> URL into your prompt.
+      </span>
+      <span class="llm-md-banner__arrow">→</span>
+    </a>
+  {% endif %}
+  {% include "partials/content.html" %}
+{% endblock %}

--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -15,7 +15,7 @@
     <a class="llm-md-banner" href="../{{ slug }}.md">
       <span class="llm-md-banner__icon">📄</span>
       <span class="llm-md-banner__text">
-        <strong>Feeding an LLM?</strong>
+        <strong>Feeding a clanker?</strong>
         Grab this page as raw markdown — drop the <code>.md</code> URL into your prompt.
       </span>
       <span class="llm-md-banner__arrow">→</span>

--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -12,13 +12,8 @@
 {% block content %}
   {% if page and "reference/" in page.url and page.url != "reference/" %}
     {% set slug = page.url | replace("reference/", "") | replace("/", "") %}
-    <a class="llm-md-banner" href="../{{ slug }}.md">
-      <span class="llm-md-banner__icon">📄</span>
-      <span class="llm-md-banner__text">
-        <strong>Feeding a clanker?</strong>
-        Grab this page as raw markdown — drop the <code>.md</code> URL into your prompt.
-      </span>
-      <span class="llm-md-banner__arrow">→</span>
+    <a class="llm-md-link" href="../{{ slug }}.md">
+      Feeding a clanker? Grab this page as raw <code>.md</code> <span class="llm-md-link__arrow">→</span>
     </a>
   {% endif %}
   {% include "partials/content.html" %}

--- a/zensical.toml
+++ b/zensical.toml
@@ -86,6 +86,15 @@ code = "Fira Mono"
 scheme = "default"
 primary = "grey"
 accent = "blue grey"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+primary = "grey"
+accent = "blue grey"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
 
 # ----------------------------------------------------------------------------
 # Extra

--- a/zensical.toml
+++ b/zensical.toml
@@ -79,8 +79,8 @@ features = [
 repo = "fontawesome/brands/github"
 
 [project.theme.font]
-text = "PT Sans"
-code = "Fira Mono"
+text = "Geist"
+code = "Geist Mono"
 
 [[project.theme.palette]]
 scheme = "default"


### PR DESCRIPTION
## Summary

- Reference pages now show a small "Feeding a clanker?" pill in the top-right linking to the page's `.md` endpoint, so users notice the LLM-friendly markdown version exists.
- Re-enables the sun/moon palette toggle (default/slate) in the header — `extra.css` already had the dark-mode overrides.
- Switches the docs font stack from PT Sans + Fira Mono to Geist + Geist Mono (picked via the ui-picker A/B against Inter and DM Sans pairings).

## Test plan

- [ ] `make docs` builds clean.
- [ ] `make docs-serve` and visit a reference page (e.g. `/reference/slider2d/`): the clanker pill floats top-right of the H1 and the linked `.md` returns 200.
- [ ] Toggle the sun/moon icon in the header and confirm the slate palette swap works.
- [ ] Page text and code blocks render in Geist / Geist Mono (Google Fonts loaded via `[project.theme.font]`).