### PR TITLE
Bump docs body text from 0.8rem to 0.85rem

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -75,6 +75,10 @@
   filter: brightness(0) invert(1);
 }
 
+.md-typeset {
+  font-size: 0.85rem;
+}
+
 /* ——————————————————————————————————————————
    Shared card styles (widget + example gallery)
    —————————————————————————————————————————— */


### PR DESCRIPTION
## Summary
- Nudges `.md-typeset` font-size up one notch from Material's 0.8rem default to 0.85rem (~13.6px) so the docs prose is a touch easier to read. Headings are untouched and continue to scale via Material's em-based rhythm.

## Test plan
- [ ] Run `make docs-serve` and confirm body text on Overview, Demos, and a Reference page reads slightly larger without disturbing heading sizes or gallery cards.
- [ ] Toggle light/dark mode to confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)