### PR TITLE
Add Steam Deck annotation example + fix AnnotationWidget voice input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added "Complex Plane Roots" to the docs gallery Examples section, linking a molab notebook by Simone Conradi that uses `ChartPuck` to visualize the argument of a monic polynomial on the complex plane.
+- Added "Steam Deck Annotations" example (`demos/steamdeck.py`, linked from the docs gallery) showing how to drive `AnnotationWidget` from a Steam Deck by mapping its buttons to keyboard keys through Steam Input, with a separate `KeystrokeWidget` section for inspecting what each button emits.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 
 - Converted docs gallery screenshots from PNG to WebP, shrinking `docs/assets/` from 6.2 MB to 1.2 MB (82% smaller).
 
+### Fixed
+
+- `AnnotationWidget` voice-input no longer duplicates finalized phrases. The widget mutated its session-base note after each finalized speech chunk, while the Web Speech API's cumulative `event.results` continued to include those chunks — so every previously finalized phrase was concatenated again on each subsequent result event.
+
 ## [0.4.1] - 2026-05-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `AnnotationWidget` voice-input no longer duplicates finalized phrases. The widget mutated its session-base note after each finalized speech chunk, while the Web Speech API's cumulative `event.results` continued to include those chunks — so every previously finalized phrase was concatenated again on each subsequent result event.
+- `AnnotationWidget` voice-input no longer duplicates finalized phrases. The `change:note` listener was synchronizing the session base text (`noteBeforeSpeech`) on every note write, including writes from the widget's own `onresult` handler — so on the next speech-result event the cumulative `event.results` array re-concatenated every already-finalized phrase onto the new base. Only sync `noteBeforeSpeech` from `change:note` when not actively recording.
+
+### Changed
+
+- `AnnotationWidget`: a keyboard shortcut mapped to the `"mic"` action is now **push-to-talk** — recording starts on keydown and stops on keyup. The mic button still toggles on click. This makes spacebar / Steam-Deck button setups behave the way you'd expect ("hold to talk").
 
 ## [0.4.1] - 2026-05-01
 

--- a/demos/steamdeck.py
+++ b/demos/steamdeck.py
@@ -117,7 +117,16 @@ def _(mo):
     ]
     get_index, set_index = mo.state(0)
     get_annotations, set_annotations = mo.state({})
-    return examples, get_annotations, get_index, set_annotations, set_index
+    get_last_ts, set_last_ts = mo.state(0.0)
+    return (
+        examples,
+        get_annotations,
+        get_index,
+        get_last_ts,
+        set_annotations,
+        set_index,
+        set_last_ts,
+    )
 
 
 @app.cell
@@ -145,23 +154,29 @@ def _(
     examples,
     get_annotations,
     get_index,
+    get_last_ts,
     set_annotations,
     set_index,
+    set_last_ts,
 ):
-    action = annot_widget.action
-    note = annot_widget.note
-    _ = annot_widget.action_timestamp
+    # Marimo re-runs this cell on *any* traitlet change, including each
+    # streamed speech token writing to `note`. Gate on `action_timestamp`
+    # so we only commit when the user actually presses an action button.
+    ts = annot_widget.action_timestamp
+    if ts > get_last_ts():
+        set_last_ts(ts)
+        action = annot_widget.action
+        note = annot_widget.note
+        _i = get_index()
+        _annots = get_annotations()
 
-    _i = get_index()
-    _annots = get_annotations()
-
-    if action in ("accept", "fail", "defer"):
-        set_annotations({**_annots, _i: {"label": action, "note": note}})
-        if _i < len(examples) - 1:
-            set_index(_i + 1)
-    elif action == "previous":
-        if _i > 0:
-            set_index(_i - 1)
+        if action in ("accept", "fail", "defer"):
+            set_annotations({**_annots, _i: {"label": action, "note": note}})
+            if _i < len(examples) - 1:
+                set_index(_i + 1)
+        elif action == "previous":
+            if _i > 0:
+                set_index(_i - 1)
     return
 
 

--- a/demos/steamdeck.py
+++ b/demos/steamdeck.py
@@ -1,0 +1,224 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo",
+#     "mohtml",
+#     "wigglystuff==0.4.1",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.23.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from wigglystuff import AnnotationWidget, KeystrokeWidget
+
+    return AnnotationWidget, KeystrokeWidget, mo
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Annotating from a Steam Deck
+
+    The Steam Deck makes a surprisingly nice annotation console. With **Steam
+    Input** you can bind any button on the Deck — including the d-pad and the
+    four back-grip buttons — to an arbitrary keyboard key. Those keys arrive
+    in the browser as ordinary `KeyboardEvent`s, which means two `wigglystuff`
+    widgets can pick them up without any extra glue:
+
+    - `KeystrokeWidget` lets you *see* what key a given button emits — handy
+      while you're wiring up the Deck's button bindings.
+    - `AnnotationWidget` lets you *act* on those keys through its
+      `keyboard_mapping` traitlet, driving an accept / fail / defer / previous
+      flow without touching the laptop's keyboard.
+
+    The two widgets are independent — this notebook demos each in its own
+    section.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Section 1 — What is the Deck sending?
+
+    Bind a button on the Deck to a keyboard key in Steam Input, click the
+    panel below to give it focus, then press the button. The widget reports
+    `key`, `code`, and any modifiers — exactly what `KeyboardEvent` would
+    show for that key on a regular keyboard.
+    """)
+    return
+
+
+@app.cell
+def _(KeystrokeWidget, mo):
+    listener = mo.ui.anywidget(KeystrokeWidget())
+    listener
+    return (listener,)
+
+
+@app.cell
+def _(listener, mo):
+    info = listener.last_key or {}
+    modifiers = [
+        label
+        for key, label in [
+            ("ctrlKey", "Ctrl"),
+            ("shiftKey", "Shift"),
+            ("altKey", "Alt"),
+            ("metaKey", "Meta"),
+        ]
+        if info.get(key)
+    ]
+    shortcut = " + ".join(modifiers + [info.get("key", "—")]).strip(" + ")
+    mo.md(
+        f"**Last key:** `{shortcut or '—'}` &nbsp;&nbsp;|&nbsp;&nbsp; "
+        f"**Code:** `{info.get('code', '—')}`"
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Section 2 — Annotating with the Deck
+
+    Once you know which keys the Deck's buttons emit, point them at
+    `AnnotationWidget`. The mapping below puts the four labels on the
+    **arrow keys** — which makes the Deck's d-pad a natural fit — and
+    binds **spacebar** to the voice-input mic toggle for free-form notes.
+
+    | Key | Action |
+    | --- | --- |
+    | `↑` | accept |
+    | `↓` | fail |
+    | `←` | previous |
+    | `→` | defer |
+    | `space` | toggle voice notes |
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    examples = [
+        "The food was absolutely delicious and the service was top notch.",
+        "Terrible experience. The waiter was rude and the steak was overcooked.",
+        "It was okay, nothing special. Might come back if nothing else is open.",
+        "Best pizza I've ever had! Will definitely return.",
+        "The ambiance was nice but the food took forever to arrive.",
+    ]
+    get_index, set_index = mo.state(0)
+    get_annotations, set_annotations = mo.state({})
+    return examples, get_annotations, get_index, set_annotations, set_index
+
+
+@app.cell
+def _(AnnotationWidget, mo):
+    annot_widget = mo.ui.anywidget(
+        AnnotationWidget(
+            actions=["previous", "accept", "fail", "defer"],
+            keyboard_mapping={
+                "arrowup": "accept",
+                "arrowdown": "fail",
+                "arrowleft": "previous",
+                "arrowright": "defer",
+                " ": "mic",
+            },
+            show_save=False,
+            width=600,
+        )
+    )
+    return (annot_widget,)
+
+
+@app.cell
+def _(
+    annot_widget,
+    examples,
+    get_annotations,
+    get_index,
+    set_annotations,
+    set_index,
+):
+    action = annot_widget.action
+    _ = annot_widget.action_timestamp
+
+    _i = get_index()
+    _annots = get_annotations()
+
+    if action in ("accept", "fail", "defer"):
+        set_annotations({**_annots, _i: action})
+        if _i < len(examples) - 1:
+            set_index(_i + 1)
+    elif action == "previous":
+        if _i > 0:
+            set_index(_i - 1)
+    return
+
+
+@app.cell
+def _(annot_widget, examples, get_index, mo):
+    _i = get_index()
+    current = examples[_i] if _i < len(examples) else "All examples labeled!"
+    mo.vstack(
+        [
+            mo.md(f"**Example {_i + 1} of {len(examples)}**"),
+            mo.md(f"> {current}"),
+            annot_widget,
+        ]
+    )
+    return
+
+
+@app.cell
+def _(examples, get_annotations, mo):
+    _annots = get_annotations()
+    rows = [
+        {
+            "index": idx,
+            "text": text[:60] + ("..." if len(text) > 60 else ""),
+            "label": _annots.get(idx, ""),
+        }
+        for idx, text in enumerate(examples)
+    ]
+    mo.md(
+        "### Annotations so far\n\n"
+        + mo.as_html(mo.ui.table(rows, selection=None)).text
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Wiring up Steam Input
+
+    On the Deck (or any Steam controller paired with a desktop):
+
+    1. Switch the Deck to **desktop mode** and open Steam.
+    2. Open **Settings → Controller** and make sure Steam Input is enabled
+       for the active layout.
+    3. Edit the layout for your browser (or use a global layout). The
+       **d-pad** is the obvious fit here — bind it to the four arrow keys
+       (most default desktop layouts already do this) and the accept /
+       fail / previous / defer actions just work. Bind a spare button —
+       e.g. one of the back grips — to **spacebar** for voice notes.
+    4. Open this notebook in the Deck's browser, click the annotation
+       widget once to give it focus, and start labeling.
+
+    Use Section 1 above any time you're unsure which key a given button is
+    emitting.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/demos/steamdeck.py
+++ b/demos/steamdeck.py
@@ -149,13 +149,14 @@ def _(
     set_index,
 ):
     action = annot_widget.action
+    note = annot_widget.note
     _ = annot_widget.action_timestamp
 
     _i = get_index()
     _annots = get_annotations()
 
     if action in ("accept", "fail", "defer"):
-        set_annotations({**_annots, _i: action})
+        set_annotations({**_annots, _i: {"label": action, "note": note}})
         if _i < len(examples) - 1:
             set_index(_i + 1)
     elif action == "previous":
@@ -185,7 +186,8 @@ def _(examples, get_annotations, mo):
         {
             "index": idx,
             "text": text[:60] + ("..." if len(text) > 60 else ""),
-            "label": _annots.get(idx, ""),
+            "label": _annots.get(idx, {}).get("label", ""),
+            "note": _annots.get(idx, {}).get("note", ""),
         }
         for idx, text in enumerate(examples)
     ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -265,4 +265,11 @@ These notebooks show how to combine multiple widgets for more complex workflows.
 </div>
 <div class="gallery-links"><a target="_blank" href="https://molab.marimo.io/notebooks/nb_qUrxbhdkek5FCCSfQiZzFU">molab</a></div>
 </div>
+<div class="example-item">
+<div class="example-content">
+<div class="example-title">Steam Deck Annotations</div>
+<div class="example-desc">Use Steam Input to map Steam Deck buttons to keyboard keys, then drive AnnotationWidget through its keyboard_mapping — with a KeystrokeWidget section for inspecting what each button emits.</div>
+</div>
+<div class="gallery-links"><a target="_blank" href="https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/steamdeck.py">molab</a><a target="_blank" href="https://github.com/koaning/wigglystuff/blob/main/demos/steamdeck.py">Source</a></div>
+</div>
 </div>

--- a/wigglystuff/static/annotation-widget.js
+++ b/wigglystuff/static/annotation-widget.js
@@ -203,12 +203,28 @@ function render({ model, el }) {
   });
 
   let keyFadeTimer = null;
+  // Key currently held that started a mic session (for push-to-talk).
+  let activeMicKey = null;
   keyArea.addEventListener("keydown", (event) => {
     event.preventDefault();
     event.stopPropagation();
     const key = event.key.toLowerCase();
     const mapping = model.get("keyboard_mapping") || {};
     const actionName = mapping[key];
+    if (actionName === "mic") {
+      // Hold-to-talk: keydown starts recording once; keyup stops it.
+      if (event.repeat) return;
+      if (!model.get("listening")) {
+        activeMicKey = key;
+        keyArea.textContent = key + " → mic (hold)";
+        triggerAction("mic");
+      }
+      clearTimeout(keyFadeTimer);
+      keyFadeTimer = setTimeout(() => {
+        keyArea.textContent = "Keyboard shortcuts active — press a key";
+      }, 350);
+      return;
+    }
     if (actionName) {
       keyArea.textContent = key + " \u2192 " + actionName;
       triggerAction(actionName);
@@ -222,6 +238,16 @@ function render({ model, el }) {
     }, 350);
   });
 
+  keyArea.addEventListener("keyup", (event) => {
+    const key = event.key.toLowerCase();
+    if (activeMicKey && key === activeMicKey) {
+      activeMicKey = null;
+      if (model.get("listening")) {
+        triggerAction("mic");
+      }
+    }
+  });
+
   // --- Note sync ---
   noteInput.addEventListener("input", () => {
     model.set("note", noteInput.value);
@@ -233,8 +259,14 @@ function render({ model, el }) {
     if (noteInput.value !== val) {
       noteInput.value = val;
     }
-    // Keep speech base text in sync so mic appends to the correct value
-    noteBeforeSpeech = val;
+    // Sync the speech-session base note — but only when we are not
+    // actively recording. Our own onresult writes to `note`, and if we
+    // overwrote noteBeforeSpeech here the cumulative event.results from
+    // the next onresult would concatenate the same finalized phrases
+    // again onto an already-grown base.
+    if (!model.get("listening")) {
+      noteBeforeSpeech = val;
+    }
   });
 
   // --- Speech-to-text ---

--- a/wigglystuff/static/annotation-widget.js
+++ b/wigglystuff/static/annotation-widget.js
@@ -255,6 +255,11 @@ function render({ model, el }) {
       };
 
       recognition.onresult = (event) => {
+        // event.results is cumulative across every onresult call in this
+        // session, so finalTranscript already contains every finalized
+        // phrase. Do not mutate noteBeforeSpeech here — doing so makes
+        // each finalized phrase get concatenated again on subsequent
+        // events and the note repeats itself.
         let finalTranscript = "";
         let interimTranscript = "";
         for (let i = 0; i < event.results.length; i++) {
@@ -264,20 +269,14 @@ function render({ model, el }) {
             interimTranscript += event.results[i][0].transcript;
           }
         }
-        // Build the full note: base + final + interim preview
         const base = noteBeforeSpeech;
-        const separator = base.length > 0 ? " " : "";
-        const confirmed = finalTranscript ? separator + finalTranscript : "";
-        const preview = interimTranscript
-          ? (base.length > 0 || finalTranscript ? " " : "") + interimTranscript
-          : "";
-        const newNote = base + confirmed + preview;
-        noteInput.value = newNote;
-        // Only sync finalized text to the model
+        const finalSep = base.length > 0 && finalTranscript ? " " : "";
+        const interimSep =
+          (base.length > 0 || finalTranscript) && interimTranscript ? " " : "";
+        noteInput.value =
+          base + finalSep + finalTranscript + interimSep + interimTranscript;
         if (finalTranscript) {
-          const finalNote = base + confirmed;
-          noteBeforeSpeech = finalNote;
-          model.set("note", finalNote);
+          model.set("note", base + finalSep + finalTranscript);
           model.save_changes();
         }
       };


### PR DESCRIPTION
## Summary

- New `demos/steamdeck.py` example showing how to drive `AnnotationWidget` from a Steam Deck by mapping its buttons to keyboard keys via Steam Input — d-pad → arrow keys (accept/fail/previous/defer), spacebar → mic for voice notes. The notebook has two separate sections: a `KeystrokeWidget` panel for inspecting what each Deck button emits, then an `AnnotationWidget` workflow over a small text-annotation task. Linked from the Examples section of `docs/index.md`.
- **Widget fix:** `AnnotationWidget` voice input no longer duplicates finalized phrases. The `change:note` listener was syncing `noteBeforeSpeech` on every note write — including the widget's own writes from `onresult` — so each finalized phrase got re-concatenated by the cumulative `event.results` on every subsequent speech event. Only sync `noteBeforeSpeech` when not actively recording.
- **Widget UX change:** a keyboard shortcut mapped to the `"mic"` action is now **push-to-talk** (keydown starts, keyup stops, key-repeat ignored). The mic button click still toggles. This matches how you'd expect spacebar / Steam-Deck-button bindings to behave.
- The demo's action cell now gates its side effects on `action_timestamp` so streaming-speech updates to `note` don't re-fire annotation actions and stamp the in-progress transcript across multiple examples.

## Test plan

- [x] `uv run marimo check demos/steamdeck.py`
- [x] `uv run demos/steamdeck.py`
- [x] `node --check wigglystuff/static/annotation-widget.js`
- [x] Manual voice-input test in Chrome — user confirms duplication is fixed and push-to-talk feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)
