### PR TITLE
Add Paint.replace_with_pil(img) for post-construction image swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `Paint.replace_with_pil(img)` replaces the canvas contents with a PIL Image after construction. Wipes any existing strokes (the canvas has no separate background layer); resizes to the widget's `(width, height)` if needed.
+
 ## [0.4.2] - 2026-05-12
 
 ### Added

--- a/demos/paint.py
+++ b/demos/paint.py
@@ -85,6 +85,31 @@ def _(div, img, transparent):
     return
 
 
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    You can also swap the canvas image after construction with `replace_with_pil(...)`. This wipes any existing strokes — the canvas has no separate background layer — and resizes the image to the widget's `(width, height)` if needed.
+
+    This is handy when you want to keep drawing on top of the output of an image model: feed the current canvas into a model (e.g. via `get_pil()`), then pipe the model's PIL output back in with `replace_with_pil(...)` to continue iterating.
+    """)
+    return
+
+
+@app.cell
+def _(Paint, mo):
+    swap = mo.ui.anywidget(Paint(height=200, width=300))
+    swap
+    return (swap,)
+
+
+@app.cell
+def _(swap):
+    from PIL import Image
+
+    swap.replace_with_pil(Image.new("RGB", (swap.width, swap.height), "tomato"))
+    return
+
+
 @app.cell
 def _():
     return

--- a/wigglystuff/paint.py
+++ b/wigglystuff/paint.py
@@ -12,6 +12,7 @@ import warnings
 
 import anywidget
 import traitlets
+from PIL import Image
 
 DEFAULT_HEIGHT = 500
 DEFAULT_WIDTH = 889
@@ -172,3 +173,13 @@ class Paint(anywidget.AnyWidget):
         if not self.base64:
             return ""
         return pil_to_base64(self.get_pil())
+
+    def replace_with_pil(self, img) -> None:
+        """Replace the canvas contents with a PIL Image.
+
+        Wipes any existing strokes — the canvas has no separate background layer.
+        The image is resized to ``(self.width, self.height)`` if needed.
+        """
+        if img.size != (self.width, self.height):
+            img = img.resize((self.width, self.height), Image.LANCZOS)
+        self.base64 = pil_to_base64(img).split(",")[1]


### PR DESCRIPTION
## Summary

- Adds `Paint.replace_with_pil(img)` to swap the canvas image after construction. Wipes any existing strokes (Paint has no separate background layer) and resizes to the widget's `(width, height)` if needed.
- Method is named `replace_with_pil` (not `set_background`) because the canvas is a single `base64` blob, and the name should reflect that the call replaces *everything*.
- Documents the new method in `demos/paint.py` with a use case: keep drawing on top of an image model's output by piping `get_pil()` → model → `replace_with_pil(...)`.

## Test plan

- [x] `uv run python -c "..."` smoke test: same-size replace updates `base64`; differently-sized PIL image is resized to `(width, height)`.
- [x] `uv run marimo check demos/paint.py` clean (apart from a pre-existing empty-cell warning).
- [x] `mo.ui.anywidget` proxy verified to forward `.replace_with_pil(...)` and `.width` correctly.
- [ ] Manual browser check in `demos/paint.py` once the demo's `wigglystuff` pin is bumped at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)