### PR TITLE
Tidy GraphWidget/Hypercube/McNugget demos

### DIFF
--- a/demos/graphwidget.py
+++ b/demos/graphwidget.py
@@ -69,13 +69,13 @@ def _(widget):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(add_node, mo):
     mo.ui.button(label="Add node from Python", on_click=add_node)
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo, widget):
     mo.vstack(
         [
@@ -131,7 +131,7 @@ def _(mo):
     return num_nodes, regenerate_button
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(num_nodes, regenerate_button):
     import random
 
@@ -182,7 +182,7 @@ def _(num_nodes, regenerate_button):
     return max_step, steps
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(PlaySlider, max_step, mo):
     play = mo.ui.anywidget(
         PlaySlider(
@@ -191,14 +191,13 @@ def _(PlaySlider, max_step, mo):
             step=1,
             interval_ms=300,
             loop=False,
-            width=720,
         )
     )
     play
     return (play,)
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(max_step, play, steps):
     step_index = int(play.value.get("value", 0))
     step_index = max(0, min(step_index, max_step))
@@ -206,7 +205,7 @@ def _(max_step, play, steps):
     return step, step_index
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(GraphWidget, mo):
     growth_graph = mo.ui.anywidget(
         GraphWidget(

--- a/demos/hypercube.py
+++ b/demos/hypercube.py
@@ -53,7 +53,7 @@ def _(mo):
     return dim, node_size
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     NODE_PALETTE = [
         "#1e40af",
@@ -108,7 +108,7 @@ def _():
     return (build_hypercube,)
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(GraphWidget, mo):
     hypercube = mo.ui.anywidget(
         GraphWidget(

--- a/demos/mcnugget_graph.py
+++ b/demos/mcnugget_graph.py
@@ -47,7 +47,7 @@ def _(mo):
     return denominations_text, limit
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(denominations_text):
     denominations = []
     for part in denominations_text.value.split(","):
@@ -64,7 +64,7 @@ def _(denominations_text):
     return (denominations,)
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(deque):
     def build_mcnugget_steps(denominations=(6, 9, 20), limit=60):
         queue = deque([0])
@@ -129,7 +129,6 @@ def _(PlaySlider, max_step, mo):
             step=1,
             interval_ms=500,
             loop=False,
-            width=720,
         )
     )
     play


### PR DESCRIPTION
## Summary
- Mark scaffolding cells (`hide_code=True`) in `demos/graphwidget.py`, `demos/hypercube.py`, and `demos/mcnugget_graph.py` so the demo UI shows only the interactive output by default.
- Drop the redundant `width=720` from two `PlaySlider` instantiations (the surrounding layout already governs width).

## Test plan
- [x] `uv run marimo check demos/{graphwidget,hypercube,mcnugget_graph}.py`
- [x] `uv run demos/{graphwidget,hypercube,mcnugget_graph}.py` runs cleanly
- [ ] Open each demo in `marimo edit` and confirm the hidden cells stay hidden and the PlaySliders still render at the expected width

🤖 Generated with [Claude Code](https://claude.com/claude-code)