### PR TITLE
Clean up AnnotationWidget save action API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `AnnotationWidget.actions` now only describes the main action buttons (`previous`, `accept`, `fail`, `defer` by default). Save remains a separate footer control governed by `show_save`; when `show_save=False`, save shortcuts are hidden and ignored.
+
 ## [0.5.3] - 2026-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `AnnotationWidget.actions` now only describes the main action buttons (`previous`, `accept`, `fail`, `defer` by default). Save remains a separate footer control governed by `show_save`; when `show_save=False`, save shortcuts are hidden and ignored.
 - `AnnotationWidget` now derives the default keyboard mapping from `actions`, assigning action buttons to number keys in order while keeping `s` for save and `m` for mic.
+- `AnnotationWidget` now derives the default gamepad mapping from `actions`, assigning action buttons to gamepad indices in order followed by save and mic.
 
 ## [0.5.3] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `AnnotationWidget.actions` now only describes the main action buttons (`previous`, `accept`, `fail`, `defer` by default). Save remains a separate footer control governed by `show_save`; when `show_save=False`, save shortcuts are hidden and ignored.
+- `AnnotationWidget` now derives the default keyboard mapping from `actions`, assigning action buttons to number keys in order while keeping `s` for save and `m` for mic.
 
 ## [0.5.3] - 2026-05-22
 

--- a/demos/annotation.py
+++ b/demos/annotation.py
@@ -50,7 +50,13 @@ def _(mo):
 
 @app.cell
 def _(AnnotationWidget, mo):
-    annot_widget = mo.ui.anywidget(AnnotationWidget(show_save=False, width=1200))
+    annot_widget = mo.ui.anywidget(
+        AnnotationWidget(
+            actions=["previous", "accept", "fail", "defer"],
+            show_save=False,
+            width=1200,
+        )
+    )
     return (annot_widget,)
 
 
@@ -184,12 +190,6 @@ def _(mo, widget):
     **Current note:** `{widget.note or "---"}`
     """)
     return
-
-
-@app.cell
-def _():
-    return
-
 
 if __name__ == "__main__":
     app.run()

--- a/demos/annotation.py
+++ b/demos/annotation.py
@@ -6,9 +6,10 @@
 #     "wigglystuff==0.3.1",
 # ]
 # ///
+
 import marimo
 
-__generated_with = "0.20.4"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -52,7 +53,7 @@ def _(mo):
 def _(AnnotationWidget, mo):
     annot_widget = mo.ui.anywidget(
         AnnotationWidget(
-            actions=["previous", "accept", "fail", "defer"],
+            actions=["previous", "accept", "left", "right", "defer"],
             show_save=False,
             width=1200,
         )
@@ -190,6 +191,7 @@ def _(mo, widget):
     **Current note:** `{widget.note or "---"}`
     """)
     return
+
 
 if __name__ == "__main__":
     app.run()

--- a/demos/steamdeck.py
+++ b/demos/steamdeck.py
@@ -133,7 +133,6 @@ def _(mo):
 def _(AnnotationWidget, mo):
     annot_widget = mo.ui.anywidget(
         AnnotationWidget(
-            actions=["previous", "accept", "fail", "defer"],
             keyboard_mapping={
                 "arrowup": "accept",
                 "arrowdown": "fail",

--- a/docs/reference/annotation.md
+++ b/docs/reference/annotation.md
@@ -14,6 +14,6 @@
 | `show_save` | `bool` | Toggles visibility and availability of the footer Save button. |
 | `actions` | `list[str]` | Ordered list of main action button labels. Defaults to `["previous", "accept", "fail", "defer"]`. |
 | `keyboard_mapping` | `dict[str, str]` | Maps keys to action names. By default, action buttons are mapped to number keys in order (`1`, `2`, ...), with `s` for save and `m` for mic. The special target `mic` toggles the speech-to-text microphone. |
-| `gamepad_mapping` | `dict[str, str]` | Maps gamepad button indices (as strings) to action names. The `mic` target works here too. |
+| `gamepad_mapping` | `dict[str, str]` | Maps gamepad button indices (as strings) to action names. By default, action buttons are mapped to gamepad buttons in order (`0`, `1`, ...), followed by save and mic. The `mic` target works here too. |
 | `debounce_ms` | `int` | Minimum interval between accepted action triggers, in milliseconds. |
 | `width` | `int` | Widget width in pixels. |

--- a/docs/reference/annotation.md
+++ b/docs/reference/annotation.md
@@ -13,7 +13,7 @@
 | `disabled` | `bool` | When `True`, all input controls are inert. |
 | `show_save` | `bool` | Toggles visibility and availability of the footer Save button. |
 | `actions` | `list[str]` | Ordered list of main action button labels. Defaults to `["previous", "accept", "fail", "defer"]`. |
-| `keyboard_mapping` | `dict[str, str]` | Maps keys to action names. The special target `mic` toggles the speech-to-text microphone. |
+| `keyboard_mapping` | `dict[str, str]` | Maps keys to action names. By default, action buttons are mapped to number keys in order (`1`, `2`, ...), with `s` for save and `m` for mic. The special target `mic` toggles the speech-to-text microphone. |
 | `gamepad_mapping` | `dict[str, str]` | Maps gamepad button indices (as strings) to action names. The `mic` target works here too. |
 | `debounce_ms` | `int` | Minimum interval between accepted action triggers, in milliseconds. |
 | `width` | `int` | Widget width in pixels. |

--- a/docs/reference/annotation.md
+++ b/docs/reference/annotation.md
@@ -11,10 +11,9 @@
 | `note` | `str` | Free-form note text, populated by typing or speech-to-text. |
 | `listening` | `bool` | `True` while speech-to-text is actively transcribing. |
 | `disabled` | `bool` | When `True`, all input controls are inert. |
-| `show_save` | `bool` | Toggles visibility of the Save button. |
-| `actions` | `list[str]` | Ordered list of action button labels. Defaults to `["previous", "accept", "fail", "defer", "save"]`. |
+| `show_save` | `bool` | Toggles visibility and availability of the footer Save button. |
+| `actions` | `list[str]` | Ordered list of main action button labels. Defaults to `["previous", "accept", "fail", "defer"]`. |
 | `keyboard_mapping` | `dict[str, str]` | Maps keys to action names. The special target `mic` toggles the speech-to-text microphone. |
 | `gamepad_mapping` | `dict[str, str]` | Maps gamepad button indices (as strings) to action names. The `mic` target works here too. |
 | `debounce_ms` | `int` | Minimum interval between accepted action triggers, in milliseconds. |
 | `width` | `int` | Widget width in pixels. |
-

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -13,6 +13,14 @@ def test_annotation_actions_do_not_include_footer_save_by_default():
         "s": "save",
         "m": "mic",
     }
+    assert widget.gamepad_mapping == {
+        "0": "previous",
+        "1": "accept",
+        "2": "fail",
+        "3": "defer",
+        "4": "save",
+        "5": "mic",
+    }
 
 
 def test_annotation_show_save_is_independent_from_actions():
@@ -37,6 +45,13 @@ def test_annotation_default_keyboard_mapping_follows_actions():
         "s": "save",
         "m": "mic",
     }
+    assert widget.gamepad_mapping == {
+        "0": "left",
+        "1": "middle",
+        "2": "right",
+        "3": "save",
+        "4": "mic",
+    }
 
 
 def test_annotation_custom_keyboard_mapping_does_not_follow_actions():
@@ -48,3 +63,25 @@ def test_annotation_custom_keyboard_mapping_does_not_follow_actions():
 
     widget.actions = ["accept", "fail"]
     assert widget.keyboard_mapping == {"a": "left", "d": "right"}
+
+
+def test_annotation_custom_gamepad_mapping_does_not_follow_actions():
+    widget = AnnotationWidget(
+        actions=["left", "right"],
+        gamepad_mapping={"0": "left", "1": "right"},
+    )
+    assert widget.gamepad_mapping == {"0": "left", "1": "right"}
+
+    widget.actions = ["accept", "fail"]
+    assert widget.gamepad_mapping == {"0": "left", "1": "right"}
+
+
+def test_annotation_empty_values_are_explicit():
+    widget = AnnotationWidget(
+        actions=[],
+        keyboard_mapping={},
+        gamepad_mapping={},
+    )
+    assert widget.actions == []
+    assert widget.keyboard_mapping == {}
+    assert widget.gamepad_mapping == {}

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -5,6 +5,14 @@ def test_annotation_actions_do_not_include_footer_save_by_default():
     widget = AnnotationWidget()
     assert widget.actions == ["previous", "accept", "fail", "defer"]
     assert widget.show_save is True
+    assert widget.keyboard_mapping == {
+        "1": "previous",
+        "2": "accept",
+        "3": "fail",
+        "4": "defer",
+        "s": "save",
+        "m": "mic",
+    }
 
 
 def test_annotation_show_save_is_independent_from_actions():
@@ -18,3 +26,33 @@ def test_annotation_show_save_is_independent_from_actions():
     widget.show_save = True
     assert widget.actions == ["previous", "accept"]
     assert widget.show_save is True
+
+
+def test_annotation_default_keyboard_mapping_follows_actions():
+    widget = AnnotationWidget(actions=["left", "middle", "right"])
+    assert widget.keyboard_mapping == {
+        "1": "left",
+        "2": "middle",
+        "3": "right",
+        "s": "save",
+        "m": "mic",
+    }
+
+    widget.actions = ["accept", "defer"]
+    assert widget.keyboard_mapping == {
+        "1": "accept",
+        "2": "defer",
+        "s": "save",
+        "m": "mic",
+    }
+
+
+def test_annotation_custom_keyboard_mapping_does_not_follow_actions():
+    widget = AnnotationWidget(
+        actions=["left", "right"],
+        keyboard_mapping={"a": "left", "d": "right"},
+    )
+    assert widget.keyboard_mapping == {"a": "left", "d": "right"}
+
+    widget.actions = ["accept", "fail"]
+    assert widget.keyboard_mapping == {"a": "left", "d": "right"}

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -38,14 +38,6 @@ def test_annotation_default_keyboard_mapping_follows_actions():
         "m": "mic",
     }
 
-    widget.actions = ["accept", "defer"]
-    assert widget.keyboard_mapping == {
-        "1": "accept",
-        "2": "defer",
-        "s": "save",
-        "m": "mic",
-    }
-
 
 def test_annotation_custom_keyboard_mapping_does_not_follow_actions():
     widget = AnnotationWidget(

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,0 +1,20 @@
+from wigglystuff import AnnotationWidget
+
+
+def test_annotation_actions_do_not_include_footer_save_by_default():
+    widget = AnnotationWidget()
+    assert widget.actions == ["previous", "accept", "fail", "defer"]
+    assert widget.show_save is True
+
+
+def test_annotation_show_save_is_independent_from_actions():
+    widget = AnnotationWidget(
+        actions=["previous", "accept"],
+        show_save=False,
+    )
+    assert widget.actions == ["previous", "accept"]
+    assert widget.show_save is False
+
+    widget.show_save = True
+    assert widget.actions == ["previous", "accept"]
+    assert widget.show_save is True

--- a/wigglystuff/annotation.py
+++ b/wigglystuff/annotation.py
@@ -39,7 +39,7 @@ class AnnotationWidget(anywidget.AnyWidget):
     # --- Configuration traitlets ---
     actions = traitlets.List(
         traitlets.Unicode(),
-        default_value=["previous", "accept", "fail", "defer", "save"],
+        default_value=["previous", "accept", "fail", "defer"],
     ).tag(sync=True)
 
     keyboard_mapping = traitlets.Dict(

--- a/wigglystuff/annotation.py
+++ b/wigglystuff/annotation.py
@@ -4,6 +4,17 @@ from typing import Any, Optional, Sequence
 import anywidget
 import traitlets
 
+DEFAULT_ACTIONS = ["previous", "accept", "fail", "defer"]
+DEFAULT_EXTRA_KEYBOARD_MAPPING = {"s": "save", "m": "mic"}
+
+
+def _default_keyboard_mapping(actions: Sequence[str]) -> dict[str, str]:
+    mapping = {
+        str(index): action
+        for index, action in enumerate(actions[:9], start=1)
+    }
+    return {**mapping, **DEFAULT_EXTRA_KEYBOARD_MAPPING}
+
 
 class AnnotationWidget(anywidget.AnyWidget):
     """Annotation input widget with buttons, keyboard shortcuts, gamepad, and speech-to-text.
@@ -39,19 +50,10 @@ class AnnotationWidget(anywidget.AnyWidget):
     # --- Configuration traitlets ---
     actions = traitlets.List(
         traitlets.Unicode(),
-        default_value=["previous", "accept", "fail", "defer"],
+        default_value=DEFAULT_ACTIONS,
     ).tag(sync=True)
 
-    keyboard_mapping = traitlets.Dict(
-        default_value={
-            "1": "previous",
-            "2": "accept",
-            "3": "fail",
-            "4": "defer",
-            "s": "save",
-            "m": "mic",
-        },
-    ).tag(sync=True)
+    keyboard_mapping = traitlets.Dict(default_value={}).tag(sync=True)
 
     gamepad_mapping = traitlets.Dict(
         default_value={
@@ -89,3 +91,23 @@ class AnnotationWidget(anywidget.AnyWidget):
         if width is not None:
             init_kwargs["width"] = width
         super().__init__(**init_kwargs, **kwargs)
+        self._keyboard_mapping_is_default = keyboard_mapping is None
+        if self._keyboard_mapping_is_default:
+            self._set_default_keyboard_mapping()
+
+    def _set_default_keyboard_mapping(self) -> None:
+        self._setting_default_keyboard_mapping = True
+        self.keyboard_mapping = _default_keyboard_mapping(self.actions or [])
+        self._setting_default_keyboard_mapping = False
+
+    @traitlets.observe("actions")
+    def _update_default_keyboard_mapping(self, change: dict[str, Any]) -> None:
+        if getattr(self, "_keyboard_mapping_is_default", False):
+            self._set_default_keyboard_mapping()
+
+    @traitlets.observe("keyboard_mapping")
+    def _mark_custom_keyboard_mapping(self, change: dict[str, Any]) -> None:
+        if getattr(self, "_setting_default_keyboard_mapping", False):
+            return
+        if hasattr(self, "_keyboard_mapping_is_default"):
+            self._keyboard_mapping_is_default = False

--- a/wigglystuff/annotation.py
+++ b/wigglystuff/annotation.py
@@ -80,10 +80,14 @@ class AnnotationWidget(anywidget.AnyWidget):
         **kwargs: Any,
     ) -> None:
         init_kwargs: dict[str, Any] = {}
+        action_list = list(actions) if actions is not None else list(DEFAULT_ACTIONS)
         if actions is not None:
-            init_kwargs["actions"] = list(actions)
-        if keyboard_mapping is not None:
-            init_kwargs["keyboard_mapping"] = dict(keyboard_mapping)
+            init_kwargs["actions"] = action_list
+        init_kwargs["keyboard_mapping"] = (
+            _default_keyboard_mapping(action_list)
+            if keyboard_mapping is None
+            else dict(keyboard_mapping)
+        )
         if gamepad_mapping is not None:
             init_kwargs["gamepad_mapping"] = dict(gamepad_mapping)
         if debounce_ms is not None:
@@ -91,23 +95,3 @@ class AnnotationWidget(anywidget.AnyWidget):
         if width is not None:
             init_kwargs["width"] = width
         super().__init__(**init_kwargs, **kwargs)
-        self._keyboard_mapping_is_default = keyboard_mapping is None
-        if self._keyboard_mapping_is_default:
-            self._set_default_keyboard_mapping()
-
-    def _set_default_keyboard_mapping(self) -> None:
-        self._setting_default_keyboard_mapping = True
-        self.keyboard_mapping = _default_keyboard_mapping(self.actions or [])
-        self._setting_default_keyboard_mapping = False
-
-    @traitlets.observe("actions")
-    def _update_default_keyboard_mapping(self, change: dict[str, Any]) -> None:
-        if getattr(self, "_keyboard_mapping_is_default", False):
-            self._set_default_keyboard_mapping()
-
-    @traitlets.observe("keyboard_mapping")
-    def _mark_custom_keyboard_mapping(self, change: dict[str, Any]) -> None:
-        if getattr(self, "_setting_default_keyboard_mapping", False):
-            return
-        if hasattr(self, "_keyboard_mapping_is_default"):
-            self._keyboard_mapping_is_default = False

--- a/wigglystuff/annotation.py
+++ b/wigglystuff/annotation.py
@@ -16,6 +16,17 @@ def _default_keyboard_mapping(actions: Sequence[str]) -> dict[str, str]:
     return {**mapping, **DEFAULT_EXTRA_KEYBOARD_MAPPING}
 
 
+def _default_gamepad_mapping(actions: Sequence[str]) -> dict[str, str]:
+    mapping = {
+        str(index): action
+        for index, action in enumerate(actions)
+    }
+    next_button = len(mapping)
+    mapping[str(next_button)] = "save"
+    mapping[str(next_button + 1)] = "mic"
+    return mapping
+
+
 class AnnotationWidget(anywidget.AnyWidget):
     """Annotation input widget with buttons, keyboard shortcuts, gamepad, and speech-to-text.
 
@@ -55,16 +66,7 @@ class AnnotationWidget(anywidget.AnyWidget):
 
     keyboard_mapping = traitlets.Dict(default_value={}).tag(sync=True)
 
-    gamepad_mapping = traitlets.Dict(
-        default_value={
-            "0": "accept",
-            "1": "fail",
-            "2": "defer",
-            "3": "previous",
-            "4": "save",
-            "5": "mic",
-        },
-    ).tag(sync=True)
+    gamepad_mapping = traitlets.Dict(default_value={}).tag(sync=True)
 
     debounce_ms = traitlets.Int(200).tag(sync=True)
     width = traitlets.Int(400).tag(sync=True)
@@ -88,8 +90,11 @@ class AnnotationWidget(anywidget.AnyWidget):
             if keyboard_mapping is None
             else dict(keyboard_mapping)
         )
-        if gamepad_mapping is not None:
-            init_kwargs["gamepad_mapping"] = dict(gamepad_mapping)
+        init_kwargs["gamepad_mapping"] = (
+            _default_gamepad_mapping(action_list)
+            if gamepad_mapping is None
+            else dict(gamepad_mapping)
+        )
         if debounce_ms is not None:
             init_kwargs["debounce_ms"] = debounce_ms
         if width is not None:

--- a/wigglystuff/static/annotation-widget.js
+++ b/wigglystuff/static/annotation-widget.js
@@ -2,6 +2,12 @@
 const ICONS = {
   previous:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>',
+  left:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>',
+  middle:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="2" fill="currentColor" stroke="none"/></svg>',
+  right:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>',
   accept:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>',
   fail:

--- a/wigglystuff/static/annotation-widget.js
+++ b/wigglystuff/static/annotation-widget.js
@@ -265,6 +265,9 @@ function render({ model, el }) {
   // --- Action trigger ---
   function canTriggerAction(name) {
     if (name === "save" && !model.get("show_save")) return false;
+    if (name !== "save" && name !== "mic" && !(model.get("actions") || []).includes(name)) {
+      return false;
+    }
     if (model.get("disabled") && name !== "previous" && name !== "save") return false;
     return true;
   }

--- a/wigglystuff/static/annotation-widget.js
+++ b/wigglystuff/static/annotation-widget.js
@@ -211,9 +211,8 @@ function render({ model, el }) {
   }
 
   function updateShortcuts() {
-    // Desired action order (filter save when hidden)
-    const actionOrder = ["previous", "accept", "fail", "defer", "mic", "save"]
-      .filter((a) => a !== "save" || model.get("show_save"));
+    const actionOrder = [...(model.get("actions") || []), "mic"];
+    if (model.get("show_save")) actionOrder.push("save");
 
     // Reverse keyboard mapping: action -> key
     const kbMapping = model.get("keyboard_mapping") || {};
@@ -258,11 +257,17 @@ function render({ model, el }) {
   model.on("change:disabled", applyDisabled);
 
   // --- Action trigger ---
+  function canTriggerAction(name) {
+    if (name === "save" && !model.get("show_save")) return false;
+    if (model.get("disabled") && name !== "previous" && name !== "save") return false;
+    return true;
+  }
+
   function triggerAction(name) {
-    if (model.get("disabled") && name !== "previous" && name !== "save") return;
+    if (!canTriggerAction(name)) return false;
     if (name === "mic") {
       toggleListening();
-      return;
+      return true;
     }
     model.set("action", name);
     model.set("action_timestamp", Date.now());
@@ -274,6 +279,7 @@ function render({ model, el }) {
       btn.classList.add("is-flash");
       setTimeout(() => btn.classList.remove("is-flash"), 200);
     }
+    return true;
   }
 
   // --- Keyboard handling (click-to-focus) ---
@@ -300,8 +306,12 @@ function render({ model, el }) {
       if (event.repeat) return;
       if (!model.get("listening")) {
         activeMicKey = event.key.toLowerCase();
-        keyArea.textContent = formatBinding(match.binding) + " → mic (hold)";
-        triggerAction("mic");
+        if (triggerAction("mic")) {
+          keyArea.textContent = formatBinding(match.binding) + " → mic (hold)";
+        } else {
+          activeMicKey = null;
+          keyArea.textContent = "\u201C" + event.key + "\u201D not mapped";
+        }
       }
       clearTimeout(keyFadeTimer);
       keyFadeTimer = setTimeout(() => {
@@ -310,8 +320,10 @@ function render({ model, el }) {
       return;
     }
     if (match) {
-      keyArea.textContent = formatBinding(match.binding) + " \u2192 " + match.action;
-      triggerAction(match.action);
+      const didTrigger = triggerAction(match.action);
+      keyArea.textContent = didTrigger
+        ? formatBinding(match.binding) + " \u2192 " + match.action
+        : "\u201C" + event.key + "\u201D not mapped";
     } else {
       keyArea.textContent = "\u201C" + event.key + "\u201D not mapped";
     }


### PR DESCRIPTION
## Summary
- make `AnnotationWidget.actions` describe only the main action buttons
- keep Save as a separate footer control governed by `show_save`
- hide and ignore save shortcuts when `show_save=False`
- update annotation docs/demos and add regression coverage

## Tests
- `uv run pytest tests/test_annotation.py`
- `node --check wigglystuff/static/annotation-widget.js`
- `uv run marimo check demos/annotation.py`
- `uv run marimo check demos/steamdeck.py`
- `uv run demos/annotation.py`
- `uv run demos/steamdeck.py`