### PR TITLE
Release 0.5.5: zoom/pan + playhead-through-edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-05-27
+
+### Added
+
+- `BezierCurve` and `CurveEditor`: drag empty space inside the axes frame to pan and use the mouse wheel to zoom toward the cursor. The view transform is pixel-space only — `x_bounds` / `y_bounds` are unchanged and no view state is synced to Python. Grid lines and axis ticks recompute against the visible range as you zoom, and the curve is clipped to the plot area so it no longer spills past the axes.
+
 ### Fixed
 
 - `BezierCurve` and `CurveEditor`: editing the curve (dragging a control point, double-clicking to add or remove a point, or toggling `closed`) no longer pauses playback. The playhead now continues across the new curve shape, matching the existing behaviour when changing the curve type or tension. Progress-slider scrubbing still pauses, since scrubbing `t` directly fights the timer.

--- a/demos/beziercurve.py
+++ b/demos/beziercurve.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.5.4",
+#     "wigglystuff==0.5.5",
 # ]
 # ///
 import marimo

--- a/demos/curve_clifford.py
+++ b/demos/curve_clifford.py
@@ -4,7 +4,7 @@
 #     "marimo",
 #     "matplotlib",
 #     "numpy",
-#     "wigglystuff==0.5.4",
+#     "wigglystuff==0.5.5",
 # ]
 # ///
 import marimo

--- a/demos/curve_normal.py
+++ b/demos/curve_normal.py
@@ -4,7 +4,7 @@
 #     "marimo",
 #     "matplotlib",
 #     "numpy",
-#     "wigglystuff==0.5.4",
+#     "wigglystuff==0.5.5",
 # ]
 # ///
 

--- a/demos/curveeditor.py
+++ b/demos/curveeditor.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.5.4",
+#     "wigglystuff==0.5.5",
 # ]
 # ///
 import marimo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.4"
+version = "0.5.5"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -3780,7 +3780,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` and `uv.lock` to **0.5.5**.
- Promotes the unreleased CHANGELOG entries — zoom-with-wheel / drag-to-pan for `BezierCurve` and `CurveEditor` (#235) and playhead-continues-through-edits fix (#234) — into a dated `## [0.5.5] - 2026-05-27` section.
- Bumps the `wigglystuff==0.5.4` pin to `0.5.5` in every demo that exercises `BezierCurve`/`CurveEditor`: `demos/beziercurve.py`, `demos/curveeditor.py`, `demos/curve_normal.py`, `demos/curve_clifford.py`.

## Test plan
- [ ] `uv build` produces a 0.5.5 wheel.
- [ ] `uv run demos/beziercurve.py` and `uv run demos/curveeditor.py` work once 0.5.5 is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)