### PR TITLE
Excalidraw widget

### DIFF
--- a/js/excalidraw/build.js
+++ b/js/excalidraw/build.js
@@ -1,0 +1,111 @@
+// Build the Excalidraw anywidget bundle.
+//
+// Usage:
+//   node js/excalidraw/build.js <git-url-or-local-path> [branch]
+//   node js/excalidraw/build.js https://github.com/rambip/excalidraw fix/shadow-dom-support
+//   node js/excalidraw/build.js /local/path/to/excalidraw-fork
+//
+// The repo is cloned into a temp dir if a URL is given.
+
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const { execSync } = require("child_process");
+const { pathToFileURL } = require("url");
+
+const arg = process.argv[2];
+const branch = process.argv[3];
+
+let FORK;
+if (!arg) {
+  throw new Error("Usage: node build.js <git-url-or-path> [branch]");
+} else if (arg.startsWith("http") || arg.startsWith("git@")) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "excalidraw-fork-"));
+  const branchFlag = branch ? `--branch ${branch} --single-branch` : "";
+  console.log(`Cloning ${arg} ${branch ?? ""} into ${tmpDir} ...`);
+  execSync(`git clone --depth 1 ${branchFlag} ${arg} ${tmpDir}`, { stdio: "inherit" });
+  execSync(`yarn install --no-immutable`, { cwd: tmpDir, stdio: "inherit" });
+  FORK = tmpDir;
+} else {
+  FORK = path.resolve(arg);
+}
+const NODE_MODULES = path.join(FORK, "node_modules");
+const PACKAGES = path.join(FORK, "packages");
+const OUT_DIR = path.resolve(__dirname, "../../wigglystuff/static");
+
+console.log(`Using fork: ${FORK}`);
+
+const { build } = require(path.join(NODE_MODULES, "esbuild"));
+const { sassPlugin } = require(path.join(NODE_MODULES, "esbuild-sass-plugin"));
+const { parseEnvVariables } = require(path.join(FORK, "packages/excalidraw/env.cjs"));
+
+const resolveRelativePath = (importPath, sourceFile) => {
+  const sourceDir = path.dirname(sourceFile);
+  for (const ext of [".scss", ".css", ""]) {
+    const fullPath = path.resolve(sourceDir, importPath + ext);
+    if (fs.existsSync(fullPath)) return fullPath;
+    const partial = path.join(path.dirname(fullPath), `_${path.basename(fullPath)}`);
+    if (fs.existsSync(partial)) return partial;
+  }
+  return null;
+};
+
+const precompile = (source, sourcePath) =>
+  source.replace(/(@use|@forward)\s+["'](\.[^"']+)["']/g, (match, directive, importPath) => {
+    const resolved = resolveRelativePath(importPath, sourcePath);
+    return resolved ? `${directive} "${pathToFileURL(resolved).href}"` : match;
+  });
+
+const ENV_VARS = {
+  ...parseEnvVariables(path.join(FORK, ".env.production")),
+  PROD: true,
+};
+
+const fontPlugin = {
+  name: "font-loader",
+  setup(build) {
+    build.onLoad({ filter: /\/Xiaolai\/index\.[jt]sx?$/ }, () => ({
+      contents: `
+        console.warn("[excalidraw] Chinese (Xiaolai) font not bundled — CJK text will use system fallback.");
+        export const XiaolaiFontFaces = [];
+      `,
+      loader: "js",
+    }));
+    build.onLoad({ filter: /\.woff2$/ }, (args) => ({
+      contents: fs.readFileSync(args.path),
+      loader: "dataurl",
+    }));
+  },
+};
+
+(async () => {
+  await build({
+    entryPoints: [path.join(__dirname, "widget.tsx")],
+    outfile: path.join(OUT_DIR, "excalidraw.js"),
+    bundle: true,
+    splitting: false,
+    format: "esm",
+    minify: true,
+    plugins: [
+      sassPlugin({ precompile, loadPaths: [path.join(FORK, "packages/excalidraw")] }),
+      fontPlugin,
+    ],
+    target: "es2020",
+    define: {
+      "import.meta.env": JSON.stringify(ENV_VARS),
+      "process.env.NODE_ENV": '"production"',
+    },
+    nodePaths: [NODE_MODULES],
+    alias: {
+      "./excalidraw-fork/packages/excalidraw/index.tsx":  path.join(PACKAGES, "excalidraw/index.tsx"),
+      "./excalidraw-fork/packages/excalidraw/types.ts":   path.join(PACKAGES, "excalidraw/types.ts"),
+      "./excalidraw-fork/packages/common/src/types.ts":   path.join(PACKAGES, "common/src/types.ts"),
+      "@excalidraw/utils":               path.join(PACKAGES, "utils/src"),
+      "@excalidraw/common":              path.join(PACKAGES, "common/src"),
+      "@excalidraw/element":             path.join(PACKAGES, "element/src"),
+      "@excalidraw/math":                path.join(PACKAGES, "math/src"),
+      "@excalidraw/fractional-indexing": path.join(PACKAGES, "fractional-indexing/src"),
+    },
+  });
+  console.log("✅ wigglystuff/static/excalidraw.{js,css}");
+})();

--- a/js/excalidraw/widget.tsx
+++ b/js/excalidraw/widget.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { Excalidraw, serializeAsJSON, loadFromBlob } from "./excalidraw-fork/packages/excalidraw/index.tsx";
+import type { BinaryFiles, ExcalidrawImperativeAPI } from "./excalidraw-fork/packages/excalidraw/types.ts";
+import type { ExcalidrawElement } from "./excalidraw-fork/packages/common/src/types.ts";
+import type { AppState } from "./excalidraw-fork/packages/excalidraw/types.ts";
+
+export * from "./excalidraw-fork/packages/excalidraw/index.tsx";
+export { React, createRoot };
+
+(globalThis as any).__excalidrawLib = { React, createRoot, Excalidraw };
+
+async function render({ model, el }: { model: any; el: HTMLElement }) {
+  el.style.height = "600px";
+
+  const mount = document.createElement("div");
+  mount.style.cssText = "width:100%;height:100%;display:block";
+  el.appendChild(mount);
+
+  // Prevent marimo from intercepting keyboard shortcuts (copy/paste etc.)
+  mount.addEventListener("keydown", (e) => e.stopPropagation());
+  mount.addEventListener("keyup", (e) => e.stopPropagation());
+
+  const root = createRoot(mount);
+
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  let pending: { elements: readonly ExcalidrawElement[]; appState: AppState; files: BinaryFiles } | null = null;
+
+  function scheduleScene(elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) {
+    pending = { elements, appState, files };
+    if (saveTimer) return; // already scheduled
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      if (!pending) return;
+      const scene = JSON.parse(serializeAsJSON(pending.elements, pending.appState, pending.files, "local"));
+      pending = null;
+      model.set("scene", scene);
+      model.save_changes();
+    }, 1000);
+  }
+
+  function parseContents(contents: string) {
+    try { return JSON.parse(contents); } catch { return null; }
+  }
+
+  function App() {
+    const apiRef = React.useRef<ExcalidrawImperativeAPI | null>(null);
+
+    const initialContents = model.get("path")?.contents ?? "";
+    const parsed = parseContents(initialContents);
+    const initialData = parsed
+      ? { elements: parsed.elements ?? [], appState: parsed.appState ?? {}, files: parsed.files ?? {} }
+      : null;
+
+    const onChange = React.useCallback(
+      (elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {
+        scheduleScene(elements, appState, files);
+      },
+      [],
+    );
+
+    // Reload when path changes (e.g. user switches file)
+    React.useEffect(() => {
+      function onPathChange() {
+        const contents = model.get("path")?.contents ?? "";
+        const p = parseContents(contents);
+        if (p && apiRef.current) {
+          apiRef.current.updateScene({
+            elements: p.elements ?? [],
+            appState: p.appState ?? {},
+          });
+        }
+      }
+      model.on("change:path", onPathChange);
+      return () => model.off("change:path", onPathChange);
+    }, []);
+
+    return React.createElement(Excalidraw, {
+      excalidrawAPI: (api: ExcalidrawImperativeAPI) => { apiRef.current = api; },
+      initialData,
+      onChange,
+    });
+  }
+
+  root.render(React.createElement(App));
+
+  requestAnimationFrame(() => window.dispatchEvent(new Event("resize")));
+
+  return () => root.unmount();
+}
+
+export default { render };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wigglystuff",
   "scripts": {
-    "build-excalidraw": "node js/excalidraw/build.js https://github.com/rambip/excalidraw fix/shadow-dom-support",
+    "build-excalidraw": "node js/excalidraw/build.js https://github.com/rambip/excalidraw master",
     "dev-copy-btn": "./node_modules/.bin/esbuild js/copybutton/widget.js --bundle --outfile=wigglystuff/static/copybutton.js --format=esm --watch --minify",
     "build-three-widget": "./node_modules/.bin/esbuild js/three-widget/widget.js --bundle --outfile=wigglystuff/static/three-widget.js --format=esm --minify",
     "dev-three-widget": "./node_modules/.bin/esbuild js/three-widget/widget.js --bundle --outfile=wigglystuff/static/three-widget.js --format=esm --watch --minify",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wigglystuff",
   "scripts": {
+    "build-excalidraw": "node js/excalidraw/build.js https://github.com/rambip/excalidraw fix/shadow-dom-support",
     "dev-copy-btn": "./node_modules/.bin/esbuild js/copybutton/widget.js --bundle --outfile=wigglystuff/static/copybutton.js --format=esm --watch --minify",
     "build-three-widget": "./node_modules/.bin/esbuild js/three-widget/widget.js --bundle --outfile=wigglystuff/static/three-widget.js --format=esm --minify",
     "dev-three-widget": "./node_modules/.bin/esbuild js/three-widget/widget.js --bundle --outfile=wigglystuff/static/three-widget.js --format=esm --watch --minify",

--- a/wigglystuff/excalidraw.py
+++ b/wigglystuff/excalidraw.py
@@ -1,0 +1,39 @@
+import anywidget
+import traitlets
+import json
+from pathlib import Path
+
+_STATIC = Path(__file__).parent / "static"
+
+
+def _path_to_json(path: Path, widget) -> dict | None:
+    if path is None:
+        return None
+    contents = path.read_text(encoding="utf-8") if path.exists() else ""
+    return {"name": path.name, "contents": contents}
+
+def _path_from_json(value, widget) -> Path | None:
+    return widget.path
+
+
+class ExcalidrawWidget(anywidget.AnyWidget):
+    _esm = (_STATIC / "excalidraw.js").read_text()
+    _css = (_STATIC / "excalidraw.css").read_text()
+
+    path = traitlets.Instance(Path, allow_none=True).tag(
+        sync=True,
+        to_json=_path_to_json,
+        from_json=_path_from_json,
+    )
+    scene = traitlets.Dict({}).tag(sync=True)
+    auto_save = traitlets.Bool(False)
+
+    @traitlets.observe("scene")
+    def _on_scene_change(self, change: dict) -> None:
+        if self.auto_save and change["new"] and self.path is not None:
+            self.path.write_text(json.dumps(change["new"]), encoding="utf-8")
+
+    def __init__(self, path: Path | str | None = None, auto_save: bool = False, **kwargs):
+        super().__init__(**kwargs)
+        self.path = Path(path) if isinstance(path, str) else path
+        self.auto_save = auto_save


### PR DESCRIPTION
I'm a bit on a rush, but most of the implementation should be there.
Note that:
- I have PR on excalidraw not merged yet, I will point to the `excalidraw` upstream branch when merged
- copy-paste behaviour may be broken
- the build-step is custom, it can probably be simplified but at least it works as is
- there is an optional auto-save feature
- sometimes performance seems a bit behind, I did not investigate why. Usable though
- it would be nice to decouple `sync js scene state` and `save to file`, not done right now