### PR TITLE
CellTour: document & demo app-mode support (marimo >= 0.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- `CellTour`: now works in marimo app mode (`marimo run` / molab) in addition to edit mode. No behavior change in the widget itself — marimo `>= 0.23` started rendering `.marimo-cell` and `[data-cell-name]` on cell containers in app mode, which is what `CellTour`'s step selectors already target. The docstring, reference page, and bundled demo (`demos/celltour.py`) have been updated to reflect this; the demo is reworked so its tour steps point at cells with visible output (so it makes sense when opened via `marimo run`) and its PEP 723 header now pins `marimo>=0.23`.
+
 ## [0.5.8] - 2026-06-04
 
 ### Added

--- a/demos/celltour.py
+++ b/demos/celltour.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "anywidget==0.9.21",
-#     "marimo",
+#     "marimo>=0.23",
 #     "numpy==2.3.5",
 #     "wigglystuff==0.3.1",
 # ]
@@ -10,41 +10,40 @@
 
 import marimo
 
-__generated_with = "0.18.4"
+__generated_with = "0.23.9"
 app = marimo.App(width="medium", sql_output="polars")
 
 
 @app.cell
-def foobar():
-    # Notice how this cell has a name?
+def setup():
     import marimo as mo
     from wigglystuff import CellTour
     return CellTour, mo
 
 
 @app.cell
-def _(CellTour, mo):
-    # CellTour provides a simpler API than DriverTour
-    # You can use cell indices OR cell names (data-cell-name attribute)
+def tour(CellTour, mo):
+    # The tour widget lives at the top of the notebook so the "Start Tour"
+    # button is reachable in both edit mode and app mode (`marimo run` /
+    # molab). Steps target other cells by their `cell_name` — which is the
+    # function name marimo uses for that cell.
     tour = mo.ui.anywidget(
         CellTour(
             steps=[
                 {
-                    # Use cell_name to target cells by their function name
-                    "cell_name": "foobar",
-                    "title": "Imports",
-                    "description": "First we import marimo and CellTour.",
+                    "cell_name": "intro",
+                    "title": "Welcome",
+                    "description": "CellTour highlights marimo cells one at a time. This works in both edit mode and app mode (since marimo 0.23).",
                 },
                 {
-                    "cell": 1,
-                    "title": "Tour Definition",
-                    "description": "This cell defines the tour using the simplified API.",
+                    "cell_name": "content",
+                    "title": "Target any named cell",
+                    "description": "Each step references a cell by `cell_name=` (its function name in marimo), which matches the `[data-cell-name]` attribute marimo renders on each cell.",
                 },
                 {
-                    # Use cell_name for the example cell
-                    "cell": 2,
-                    "title": "Example Code",
-                    "description": "This cell shows some example code.",
+                    "cell_name": "summary",
+                    "title": "That's it",
+                    "description": "Use CellTour to build short product tours for marimo apps you share — onboarding, walkthroughs, or guided demos.",
                 },
             ]
         )
@@ -54,11 +53,37 @@ def _(CellTour, mo):
 
 
 @app.cell
-def _():
-    # Example code cell
-    x = 1
-    y = 2
-    z = x + y
+def intro(mo):
+    mo.md("""
+    # CellTour demo
+
+    A small guided tour over the cells below. Press **Start Tour** above
+    to step through the highlights.
+    """)
+    return
+
+
+@app.cell
+def content(mo):
+    mo.md("""
+    ## The content cell
+
+    This cell has visible output, so it shows up as a tour target in
+    app mode. In `marimo run` / molab, only cells with output are
+    rendered — pointing a tour step at an imports-only cell would
+    leave nothing to highlight.
+    """)
+    return
+
+
+@app.cell
+def summary(mo):
+    mo.md("""
+    ## Wrap-up
+
+    The tour finishes here. You can rerun it any time by pressing the
+    **Start Tour** button at the top of the page.
+    """)
     return
 
 

--- a/docs/reference/cell-tour.md
+++ b/docs/reference/cell-tour.md
@@ -2,6 +2,11 @@
 
 ::: wigglystuff.cell_tour.CellTour
 
+`CellTour` works in both marimo edit mode and app mode (`marimo run` /
+molab). The cell selectors it emits (`.marimo-cell` and
+`[data-cell-name="…"]`) require marimo `>= 0.23`, when app mode started
+rendering those markers on cell containers.
+
 ## Synced traitlets
 
 | Traitlet | Type | Notes |

--- a/wigglystuff/cell_tour.py
+++ b/wigglystuff/cell_tour.py
@@ -7,7 +7,10 @@ class CellTour(DriverTour):
     """Simplified tour widget for marimo notebooks.
 
     Wraps ``DriverTour`` with cell-aware step helpers so you can reference
-    marimo cells by index or `data-cell-name` attributes.
+    marimo cells by index or `data-cell-name` attributes. Works in both
+    marimo edit mode and app mode (``marimo run`` / molab); the cell
+    selectors require marimo ``>= 0.23``, when app mode started rendering
+    ``.marimo-cell`` and ``[data-cell-name]`` on cell containers.
 
     Examples:
         Using cell indices:


### PR DESCRIPTION
## Summary

- Marimo 0.23 started rendering `.marimo-cell` and `[data-cell-name]` on cell containers in app mode, so `CellTour`'s existing selectors now work in `marimo run` / molab without any code change.
- Updates the docstring, reference page, and CHANGELOG (`## [Unreleased]`) to advertise app-mode support.
- Reworks `demos/celltour.py` so the tour widget sits at the top and steps target named cells with visible `mo.md` output (the previous demo pointed at an imports-only and a bare-assignment cell, which render nothing in app mode). Pins `marimo>=0.23` in the PEP 723 header.

## Test plan

- [x] `uv run marimo check demos/celltour.py` (exit 0, no warnings)
- [x] `uv run demos/celltour.py` (exit 0)
- [x] `uv run python -c "from wigglystuff import CellTour; ..."` smoke (selector emission unchanged)
- [ ] Eyeball `uv run marimo edit demos/celltour.py` — tour highlights `intro` / `content` / `summary` cells
- [ ] Eyeball `uv run marimo run demos/celltour.py` — same in app mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)