### PR TITLE
Docs: show mo.ui.anywidget(...) idiom in every widget example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Docs: every widget's reference example now shows the marimo idiom `mo.ui.anywidget(...)` (wrapping the widget so its state syncs reactively in marimo), matching how the `demos/` notebooks use these widgets. The examples are auto-generated from class docstrings, so the rendered reference pages stay in sync.
+
 ## [0.5.8] - 2026-06-04
 
 ### Added

--- a/wigglystuff/altair_widget.py
+++ b/wigglystuff/altair_widget.py
@@ -19,13 +19,14 @@ class AltairWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         import altair as alt
         import pandas as pd
         from wigglystuff import AltairWidget
 
         df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
         chart = alt.Chart(df).mark_point().encode(x="x", y="y")
-        widget = AltairWidget(chart)
+        widget = mo.ui.anywidget(AltairWidget(chart))
         widget
         ```
     """

--- a/wigglystuff/annotation.py
+++ b/wigglystuff/annotation.py
@@ -39,9 +39,10 @@ class AnnotationWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import AnnotationWidget
 
-        widget = AnnotationWidget()
+        widget = mo.ui.anywidget(AnnotationWidget())
         widget
         ```
     """

--- a/wigglystuff/api_doc.py
+++ b/wigglystuff/api_doc.py
@@ -152,9 +152,10 @@ class ApiDoc(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import ApiDoc
 
-        ApiDoc(MyClass)
+        mo.ui.anywidget(ApiDoc(MyClass))
         ```
     """
 

--- a/wigglystuff/bezier_curve.py
+++ b/wigglystuff/bezier_curve.py
@@ -87,9 +87,10 @@ class BezierCurve(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import BezierCurve
 
-        curve = BezierCurve(closed=True, loop=True)
+        curve = mo.ui.anywidget(BezierCurve(closed=True, loop=True))
         curve
         ```
     """

--- a/wigglystuff/cell_tour.py
+++ b/wigglystuff/cell_tour.py
@@ -13,24 +13,26 @@ class CellTour(DriverTour):
         Using cell indices:
 
         ```python
+        import marimo as mo
         from wigglystuff import CellTour
 
-        tour = CellTour(steps=[
+        tour = mo.ui.anywidget(CellTour(steps=[
             {"cell": 0, "title": "Imports", "description": "Load libraries"},
             {"cell": 2, "title": "Processing", "description": "Data transformation"},
-        ])
+        ]))
         tour
         ```
 
         Using cell names (requires naming cells in marimo):
 
         ```python
+        import marimo as mo
         from wigglystuff import CellTour
 
-        tour = CellTour(steps=[
+        tour = mo.ui.anywidget(CellTour(steps=[
             {"cell_name": "imports", "title": "Imports", "description": "Load libraries"},
             {"cell_name": "process", "title": "Processing", "description": "Transform data"},
-        ])
+        ]))
         tour
         ```
     """

--- a/wigglystuff/chart_multi_select.py
+++ b/wigglystuff/chart_multi_select.py
@@ -26,13 +26,14 @@ class ChartMultiSelect(AnyWidget):
         Basic usage:
 
         ```python
+        import marimo as mo
         import matplotlib.pyplot as plt
         from wigglystuff import ChartMultiSelect
 
         fig, ax = plt.subplots()
         ax.scatter(x_data, y_data)
 
-        ms = ChartMultiSelect(fig, n_classes=3)
+        ms = mo.ui.anywidget(ChartMultiSelect(fig, n_classes=3))
         # ms.selections is a list of selection dicts
         # ms.get_labels(x_data, y_data) returns class labels
         ```

--- a/wigglystuff/chart_puck.py
+++ b/wigglystuff/chart_puck.py
@@ -56,19 +56,22 @@ class ChartPuck(anywidget.AnyWidget):
     Examples:
         Single puck:
         ```python
+        import marimo as mo
         import matplotlib.pyplot as plt
         from wigglystuff import ChartPuck
 
         fig, ax = plt.subplots()
         ax.scatter([1, 2, 3], [1, 2, 3])
 
-        puck = ChartPuck(fig)
+        puck = mo.ui.anywidget(ChartPuck(fig))
         # puck.x, puck.y track the puck position in data coordinates
         ```
 
         Multiple pucks:
         ```python
-        puck = ChartPuck(fig, x=[0.5, 1.5, 2.5], y=[0.5, 1.5, 2.5])
+        import marimo as mo
+
+        puck = mo.ui.anywidget(ChartPuck(fig, x=[0.5, 1.5, 2.5], y=[0.5, 1.5, 2.5]))
         # puck.x, puck.y are lists of coordinates
         ```
     """

--- a/wigglystuff/chart_select.py
+++ b/wigglystuff/chart_select.py
@@ -32,13 +32,14 @@ class ChartSelect(AnyWidget):
         Basic usage:
 
         ```python
+        import marimo as mo
         import matplotlib.pyplot as plt
         from wigglystuff import ChartSelect
 
         fig, ax = plt.subplots()
         ax.scatter(x_data, y_data)
 
-        select = ChartSelect(fig)
+        select = mo.ui.anywidget(ChartSelect(fig))
         # select.selection contains the selection bounds/vertices
         # select.has_selection is True when a selection exists
         ```

--- a/wigglystuff/circular_slider.py
+++ b/wigglystuff/circular_slider.py
@@ -38,9 +38,10 @@ class CircularSlider(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import CircularSlider
 
-        dial = CircularSlider(start=0, stop=100, step=1, value=42)
+        dial = mo.ui.anywidget(CircularSlider(start=0, stop=100, step=1, value=42))
         dial
         ```
     """
@@ -119,9 +120,10 @@ class CircularRangeSlider(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import CircularRangeSlider
 
-        span = CircularRangeSlider(start=0, stop=100, step=1, value=(20, 80))
+        span = mo.ui.anywidget(CircularRangeSlider(start=0, stop=100, step=1, value=(20, 80)))
         span
         ```
     """

--- a/wigglystuff/color_picker.py
+++ b/wigglystuff/color_picker.py
@@ -10,9 +10,10 @@ class ColorPicker(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import ColorPicker
 
-        picker = ColorPicker(color="#ff5733")
+        picker = mo.ui.anywidget(ColorPicker(color="#ff5733"))
         picker
         ```
     """

--- a/wigglystuff/copy_to_clipboard.py
+++ b/wigglystuff/copy_to_clipboard.py
@@ -10,9 +10,10 @@ class CopyToClipboard(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import CopyToClipboard
 
-        button = CopyToClipboard(text_to_copy="Hello, world!")
+        button = mo.ui.anywidget(CopyToClipboard(text_to_copy="Hello, world!"))
         button
         ```
     """

--- a/wigglystuff/curve_editor.py
+++ b/wigglystuff/curve_editor.py
@@ -110,9 +110,10 @@ class CurveEditor(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import CurveEditor
 
-        editor = CurveEditor(curve="catmull_rom", alpha=0.5)
+        editor = mo.ui.anywidget(CurveEditor(curve="catmull_rom", alpha=0.5))
         editor
         ```
     """

--- a/wigglystuff/edge_draw.py
+++ b/wigglystuff/edge_draw.py
@@ -15,9 +15,10 @@ class EdgeDraw(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import EdgeDraw
 
-        graph = EdgeDraw(names=["A", "B", "C", "D"])
+        graph = mo.ui.anywidget(EdgeDraw(names=["A", "B", "C", "D"]))
         graph
         ```
     """

--- a/wigglystuff/env_config.py
+++ b/wigglystuff/env_config.py
@@ -21,17 +21,18 @@ class EnvConfig(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import EnvConfig
 
         # Simple usage - just check vars exist
-        config = EnvConfig(["OPENAI_API_KEY", "ANTHROPIC_API_KEY"])
+        config = mo.ui.anywidget(EnvConfig(["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]))
         config
 
         # With validators
-        config = EnvConfig({
+        config = mo.ui.anywidget(EnvConfig({
             "OPENAI_API_KEY": lambda k: openai.Client(api_key=k).models.list(),
             "ANTHROPIC_API_KEY": None,  # Just check existence
-        })
+        }))
 
         # Block until valid
         config.require_valid()

--- a/wigglystuff/excalidraw.py
+++ b/wigglystuff/excalidraw.py
@@ -26,9 +26,10 @@ class Excalidraw(anywidget.AnyWidget):
 
     Example:
         ```python
+        import marimo as mo
         from wigglystuff import Excalidraw
 
-        draw = Excalidraw()
+        draw = mo.ui.anywidget(Excalidraw())
         draw
         ```
 

--- a/wigglystuff/gamepad.py
+++ b/wigglystuff/gamepad.py
@@ -12,9 +12,10 @@ class GamepadWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import GamepadWidget
 
-        gamepad = GamepadWidget()
+        gamepad = mo.ui.anywidget(GamepadWidget())
         gamepad
         ```
     """

--- a/wigglystuff/graph_widget.py
+++ b/wigglystuff/graph_widget.py
@@ -24,7 +24,13 @@ class GraphWidget(anywidget.AnyWidget):
     height (default 400).
 
     Example:
-        ``GraphWidget(nodes=["Alpha", "Beta"], edges=[("Alpha", "Beta")])``
+        ```python
+        import marimo as mo
+        from wigglystuff import GraphWidget
+
+        widget = mo.ui.anywidget(GraphWidget(nodes=["Alpha", "Beta"], edges=[("Alpha", "Beta")]))
+        widget
+        ```
     """
 
     _esm = Path(__file__).parent / "static" / "graph-widget.js"

--- a/wigglystuff/hover_zoom.py
+++ b/wigglystuff/hover_zoom.py
@@ -21,16 +21,17 @@ class HoverZoom(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import HoverZoom
 
         # From a file path
-        widget = HoverZoom("photo.jpg", zoom_factor=3.0)
+        widget = mo.ui.anywidget(HoverZoom("photo.jpg", zoom_factor=3.0))
 
         # From a matplotlib figure
         import matplotlib.pyplot as plt
         fig, ax = plt.subplots()
         ax.scatter(x, y, s=5, alpha=0.5)
-        widget = HoverZoom(fig, zoom_factor=4.0)
+        widget = mo.ui.anywidget(HoverZoom(fig, zoom_factor=4.0))
         ```
     """
 

--- a/wigglystuff/html.py
+++ b/wigglystuff/html.py
@@ -20,6 +20,7 @@ class ImageRefreshWidget(anywidget.AnyWidget):
     Example:
 
     ```python
+    import marimo as mo
     from wigglystuff import ImageRefreshWidget
     from wigglystuff.utils import refresh_matplotlib
     import matplotlib.pylab as plt
@@ -29,7 +30,7 @@ class ImageRefreshWidget(anywidget.AnyWidget):
     def plot_data(data):
         plt.plot(np.arange(len(data)), np.cumsum(data))
 
-    widget = ImageRefreshWidget(src=plot_data([1, 2, 3, 4]))
+    widget = mo.ui.anywidget(ImageRefreshWidget(src=plot_data([1, 2, 3, 4])))
 
     # Update the widget with new data
     widget.src = plot_data([1, 2, 3, 4, 5, 6])
@@ -66,9 +67,10 @@ class HTMLRefreshWidget(anywidget.AnyWidget):
 
     ```python
     import time
+    import marimo as mo
     from wigglystuff import HTMLRefreshWidget
 
-    widget = HTMLRefreshWidget(html="<p>Hello!</p>")
+    widget = mo.ui.anywidget(HTMLRefreshWidget(html="<p>Hello!</p>"))
 
     # Update the widget with dynamic content
     for i in range(10):
@@ -115,9 +117,10 @@ class ProgressBar(anywidget.AnyWidget):
 
     ```python
     import time
+    import marimo as mo
     from wigglystuff import ProgressBar
 
-    progress = ProgressBar(value=0, max_value=100)
+    progress = mo.ui.anywidget(ProgressBar(value=0, max_value=100))
 
     for i in range(101):
         progress.value = i

--- a/wigglystuff/keystroke.py
+++ b/wigglystuff/keystroke.py
@@ -16,9 +16,10 @@ class KeystrokeWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import KeystrokeWidget
 
-        keystroke = KeystrokeWidget()
+        keystroke = mo.ui.anywidget(KeystrokeWidget())
         keystroke
         ```
     """

--- a/wigglystuff/matrix.py
+++ b/wigglystuff/matrix.py
@@ -18,9 +18,10 @@ class Matrix(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import Matrix
 
-        matrix = Matrix(rows=3, cols=3, min_value=0, max_value=10)
+        matrix = mo.ui.anywidget(Matrix(rows=3, cols=3, min_value=0, max_value=10))
         matrix
         ```
     """

--- a/wigglystuff/module_tree.py
+++ b/wigglystuff/module_tree.py
@@ -147,6 +147,7 @@ class ModuleTreeWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         import torch.nn as nn
         from wigglystuff import ModuleTreeWidget
 
@@ -155,7 +156,7 @@ class ModuleTreeWidget(anywidget.AnyWidget):
             nn.ReLU(),
             nn.Linear(256, 10),
         )
-        ModuleTreeWidget(model, initial_expand_depth=2)
+        mo.ui.anywidget(ModuleTreeWidget(model, initial_expand_depth=2))
         ```
     """
 

--- a/wigglystuff/neo4j_widget.py
+++ b/wigglystuff/neo4j_widget.py
@@ -10,11 +10,12 @@ class Neo4jWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from neo4j import GraphDatabase
         from wigglystuff import Neo4jWidget
 
         driver = GraphDatabase.driver("bolt://localhost:7687", auth=("neo4j", "password"))
-        widget = Neo4jWidget(driver)
+        widget = mo.ui.anywidget(Neo4jWidget(driver))
         widget
         ```
     """

--- a/wigglystuff/nested_table.py
+++ b/wigglystuff/nested_table.py
@@ -45,9 +45,10 @@ class NestedTable(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import NestedTable
 
-        widget = NestedTable.from_paths(
+        widget = mo.ui.anywidget(NestedTable.from_paths(
             {
                 "analytics/cluster/Agg": {"hours": 12.5, "count": 5},
                 "analytics/graph/Shortest": {"hours": 6.0, "count": 2},
@@ -55,7 +56,7 @@ class NestedTable(anywidget.AnyWidget):
             },
             format={"hours": lambda v: f"{v:.1f}h"},
             show_percent=["hours"],
-        )
+        ))
         widget
         ```
     """
@@ -130,16 +131,17 @@ class NestedTable(anywidget.AnyWidget):
 
         Examples:
             ```python
+            import marimo as mo
             from wigglystuff import NestedTable
 
-            NestedTable.from_paths(
+            mo.ui.anywidget(NestedTable.from_paths(
                 {
                     "analytics/cluster/Agg": {"hours": 12.5, "count": 5},
                     "analytics/graph/Shortest": {"hours": 6.0, "count": 2},
                     "animate/Easing": {"hours": 4.25, "count": 8},
                 },
                 show_percent=["hours"],
-            )
+            ))
             ```
         """
         return cls(tree_from_paths(mapping, sep=sep, root_name=root_name), **kwargs)
@@ -158,9 +160,10 @@ class NestedTable(anywidget.AnyWidget):
 
         Examples:
             ```python
+            import marimo as mo
             from wigglystuff import NestedTable
 
-            NestedTable.from_records(
+            mo.ui.anywidget(NestedTable.from_records(
                 [
                     {"team": "analytics", "project": "cluster", "hours": 12.5},
                     {"team": "analytics", "project": "graph", "hours": 6.0},
@@ -168,7 +171,7 @@ class NestedTable(anywidget.AnyWidget):
                 ],
                 path_cols=["team", "project"],
                 value_cols="hours",
-            )
+            ))
             ```
         """
         tree = tree_from_records(
@@ -190,6 +193,7 @@ class NestedTable(anywidget.AnyWidget):
 
         Examples:
             ```python
+            import marimo as mo
             import pandas as pd
             from wigglystuff import NestedTable
 
@@ -201,11 +205,11 @@ class NestedTable(anywidget.AnyWidget):
                     "count": [5, 2, 8],
                 }
             )
-            NestedTable.from_dataframe(
+            mo.ui.anywidget(NestedTable.from_dataframe(
                 df,
                 path_cols=["team", "project"],
                 value_cols=["hours", "count"],
-            )
+            ))
             ```
         """
         tree = tree_from_dataframe(

--- a/wigglystuff/paint.py
+++ b/wigglystuff/paint.py
@@ -92,9 +92,10 @@ class Paint(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import Paint
 
-        paint = Paint(width=400, height=300)
+        paint = mo.ui.anywidget(Paint(width=400, height=300))
         paint
         ```
     """

--- a/wigglystuff/parallel_coords.py
+++ b/wigglystuff/parallel_coords.py
@@ -36,6 +36,7 @@ class ParallelCoordinates(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import ParallelCoordinates
         import polars as pl
 
@@ -44,7 +45,7 @@ class ParallelCoordinates(anywidget.AnyWidget):
             "y": [5, 4, 3, 2, 1],
             "label": ["a", "a", "b", "b", "b"],
         })
-        widget = ParallelCoordinates(df, color_by="label", color_map={"a": "red"})
+        widget = mo.ui.anywidget(ParallelCoordinates(df, color_by="label", color_map={"a": "red"}))
         widget
         ```
     """

--- a/wigglystuff/play_slider.py
+++ b/wigglystuff/play_slider.py
@@ -10,9 +10,10 @@ class PlaySlider(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import PlaySlider
 
-        slider = PlaySlider(min_value=0, max_value=50, step=1, interval_ms=300)
+        slider = mo.ui.anywidget(PlaySlider(min_value=0, max_value=50, step=1, interval_ms=300))
         slider
         ```
     """

--- a/wigglystuff/ridgeline_chart.py
+++ b/wigglystuff/ridgeline_chart.py
@@ -16,8 +16,10 @@ class RidgelineChart(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         import pandas as pd
         import numpy as np
+        from wigglystuff import RidgelineChart
 
         # Generate sample waveform data
         n_rows = 40
@@ -34,7 +36,7 @@ class RidgelineChart(anywidget.AnyWidget):
         df = pd.DataFrame(data)
         df.index = range(10, 10 + n_rows)  # Custom index
 
-        chart = RidgelineChart(df, x_label="Time", y_label="Channel")
+        chart = mo.ui.anywidget(RidgelineChart(df, x_label="Time", y_label="Channel"))
         chart
         ```
     """

--- a/wigglystuff/scatter_widget.py
+++ b/wigglystuff/scatter_widget.py
@@ -16,9 +16,10 @@ class ScatterWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import ScatterWidget
 
-        widget = ScatterWidget(n_classes=3)
+        widget = mo.ui.anywidget(ScatterWidget(n_classes=3))
         widget
         ```
     """

--- a/wigglystuff/slider2d.py
+++ b/wigglystuff/slider2d.py
@@ -13,9 +13,10 @@ class Slider2D(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import Slider2D
 
-        slider = Slider2D(x=0.5, y=0.5, x_bounds=(0.0, 1.0), y_bounds=(0.0, 1.0))
+        slider = mo.ui.anywidget(Slider2D(x=0.5, y=0.5, x_bounds=(0.0, 1.0), y_bounds=(0.0, 1.0)))
         slider
         ```
     """

--- a/wigglystuff/sortable_list.py
+++ b/wigglystuff/sortable_list.py
@@ -10,9 +10,10 @@ class SortableList(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import SortableList
 
-        sortable = SortableList(value=["apple", "banana", "cherry"], removable=True)
+        sortable = mo.ui.anywidget(SortableList(value=["apple", "banana", "cherry"], removable=True))
         sortable
         ```
     """

--- a/wigglystuff/spline_draw.py
+++ b/wigglystuff/spline_draw.py
@@ -22,6 +22,7 @@ class SplineDraw(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import SplineDraw
         from sklearn.pipeline import make_pipeline
         from sklearn.preprocessing import SplineTransformer
@@ -34,7 +35,7 @@ class SplineDraw(anywidget.AnyWidget):
             x_curve = np.linspace(x.min(), x.max(), 200)
             return x_curve, pipe.predict(x_curve.reshape(-1, 1))
 
-        widget = SplineDraw(spline_fn=spline_fn)
+        widget = mo.ui.anywidget(SplineDraw(spline_fn=spline_fn))
         widget
         ```
     """

--- a/wigglystuff/talk.py
+++ b/wigglystuff/talk.py
@@ -12,9 +12,10 @@ class WebkitSpeechToTextWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import WebkitSpeechToTextWidget
 
-        speech = WebkitSpeechToTextWidget()
+        speech = mo.ui.anywidget(WebkitSpeechToTextWidget())
         speech
         ```
     """

--- a/wigglystuff/tangle.py
+++ b/wigglystuff/tangle.py
@@ -10,9 +10,10 @@ class TangleSlider(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import TangleSlider
 
-        slider = TangleSlider(amount=50, min_value=0, max_value=100)
+        slider = mo.ui.anywidget(TangleSlider(amount=50, min_value=0, max_value=100))
         slider
         ```
     """
@@ -98,9 +99,10 @@ class TangleChoice(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import TangleChoice
 
-        choice = TangleChoice(choices=["small", "medium", "large"])
+        choice = mo.ui.anywidget(TangleChoice(choices=["small", "medium", "large"]))
         choice
         ```
     """
@@ -126,9 +128,10 @@ class TangleSelect(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import TangleSelect
 
-        select = TangleSelect(choices=["red", "green", "blue"])
+        select = mo.ui.anywidget(TangleSelect(choices=["red", "green", "blue"]))
         select
         ```
     """

--- a/wigglystuff/text_compare.py
+++ b/wigglystuff/text_compare.py
@@ -16,12 +16,13 @@ class TextCompare(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import TextCompare
 
-        compare = TextCompare(
+        compare = mo.ui.anywidget(TextCompare(
             text_a="The quick brown fox jumps over the lazy dog.",
             text_b="A quick brown fox leaps over a lazy dog."
-        )
+        ))
         compare
         ```
     """

--- a/wigglystuff/three_widget.py
+++ b/wigglystuff/three_widget.py
@@ -15,13 +15,14 @@ class ThreeWidget(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import ThreeWidget
 
         data = [
             {"x": 1.0, "y": 2.0, "z": 3.0, "color": "tomato", "size": 0.2},
             {"x": -1.0, "y": 0.5, "z": -2.0, "color": "#22c55e", "size": 0.15},
         ]
-        widget = ThreeWidget(data=data, show_grid=True, show_axes=True)
+        widget = mo.ui.anywidget(ThreeWidget(data=data, show_grid=True, show_axes=True))
         widget
         ```
     """

--- a/wigglystuff/treemap.py
+++ b/wigglystuff/treemap.py
@@ -46,15 +46,18 @@ class Treemap(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import Treemap
 
-        Treemap.from_paths(
-            {
-                "analytics/cluster/Agg": {"hours": 10, "count": 5},
-                "analytics/graph/Shortest": {"hours": 6, "count": 2},
-                "animate/Easing": {"hours": 4, "count": 8},
-            },
-            value_col="hours",
+        mo.ui.anywidget(
+            Treemap.from_paths(
+                {
+                    "analytics/cluster/Agg": {"hours": 10, "count": 5},
+                    "analytics/graph/Shortest": {"hours": 6, "count": 2},
+                    "animate/Easing": {"hours": 4, "count": 8},
+                },
+                value_col="hours",
+            )
         )
         ```
     """
@@ -130,15 +133,18 @@ class Treemap(anywidget.AnyWidget):
 
         Examples:
             ```python
+            import marimo as mo
             from wigglystuff import Treemap
 
-            Treemap.from_paths(
-                {
-                    "analytics/cluster/Agg": {"hours": 10, "count": 5},
-                    "analytics/graph/Shortest": {"hours": 6, "count": 2},
-                    "animate/Easing": {"hours": 4, "count": 8},
-                },
-                value_col="hours",
+            mo.ui.anywidget(
+                Treemap.from_paths(
+                    {
+                        "analytics/cluster/Agg": {"hours": 10, "count": 5},
+                        "analytics/graph/Shortest": {"hours": 6, "count": 2},
+                        "animate/Easing": {"hours": 4, "count": 8},
+                    },
+                    value_col="hours",
+                )
             )
             ```
         """
@@ -158,16 +164,19 @@ class Treemap(anywidget.AnyWidget):
 
         Examples:
             ```python
+            import marimo as mo
             from wigglystuff import Treemap
 
-            Treemap.from_records(
-                [
-                    {"team": "analytics", "project": "cluster", "hours": 10},
-                    {"team": "analytics", "project": "graph", "hours": 6},
-                    {"team": "animate", "project": "easing", "hours": 4},
-                ],
-                path_cols=["team", "project"],
-                value_cols="hours",
+            mo.ui.anywidget(
+                Treemap.from_records(
+                    [
+                        {"team": "analytics", "project": "cluster", "hours": 10},
+                        {"team": "analytics", "project": "graph", "hours": 6},
+                        {"team": "animate", "project": "easing", "hours": 4},
+                    ],
+                    path_cols=["team", "project"],
+                    value_cols="hours",
+                )
             )
             ```
         """
@@ -191,6 +200,7 @@ class Treemap(anywidget.AnyWidget):
 
         Examples:
             ```python
+            import marimo as mo
             import pandas as pd
             from wigglystuff import Treemap
 
@@ -201,10 +211,12 @@ class Treemap(anywidget.AnyWidget):
                     "hours": [10, 6, 4],
                 }
             )
-            Treemap.from_dataframe(
-                df,
-                path_cols=["team", "project"],
-                value_cols="hours",
+            mo.ui.anywidget(
+                Treemap.from_dataframe(
+                    df,
+                    path_cols=["team", "project"],
+                    value_cols="hours",
+                )
             )
             ```
         """

--- a/wigglystuff/webcam_capture.py
+++ b/wigglystuff/webcam_capture.py
@@ -20,9 +20,10 @@ class WebcamCapture(anywidget.AnyWidget):
 
     Examples:
         ```python
+        import marimo as mo
         from wigglystuff import WebcamCapture
 
-        cam = WebcamCapture(interval_ms=1000)
+        cam = mo.ui.anywidget(WebcamCapture(interval_ms=1000))
         cam
         ```
     """


### PR DESCRIPTION
Widget reference pages are auto-generated from each class's docstring, but none of the ~40 examples used the `mo.ui.anywidget(...)` marimo idiom that every `demos/` notebook relies on. This wraps each example's construction in `mo.ui.anywidget(...)` (adding `import marimo as mo`) so the rendered reference pages teach reactive usage — follow-up helper-method, attribute, and subscript calls still work through the wrapper (verified). Touches docstrings only across 38 widget modules plus an `## [Unreleased]` CHANGELOG note; no executable code, and `make docs` confirms all 42 rendered reference pages now show the idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)