### PR TITLE
Release 0.5.9: Excalidraw.save() remembers its path (issue #248)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ syncs back to Python.
 | EdgeDraw | `wigglystuff.edge_draw.EdgeDraw` | `names`, `links`, `directed`, `width`, `height` | Sketch node/link diagrams and query adjacency |
 | GraphWidget | `wigglystuff.graph_widget.GraphWidget` | `nodes`, `edges`, `directed`, `width`, `height`, `selected_nodes`, `selected_edges` | Programmatic force-directed graph visualization |
 | Paint | `wigglystuff.paint.Paint` | `base64`, `width`, `height`, `store_background` | MS-Paint-style canvas with PIL helpers |
-| Excalidraw | `wigglystuff.excalidraw.Excalidraw` | `scene`, `image_base64`, `theme`, `height`, `sync_throttle_ms` | Embedded Excalidraw whiteboard (loads from CDN); `get_pil`/`save`/`from_file` helpers |
+| Excalidraw | `wigglystuff.excalidraw.Excalidraw` | `scene`, `image_base64`, `theme`, `height`, `sync_throttle_ms` | Embedded Excalidraw whiteboard (loads from CDN); `get_pil`/`save`/`from_file` helpers (`save()` remembers the path) |
 | ParallelCoordinates | `wigglystuff.parallel_coords.ParallelCoordinates` | `data`, `color_by`, `height`, `filtered_indices`, `selected_indices`, `brush_extents`, `selections` | HiPlot-powered parallel coordinates with brush filtering and axis reordering |
 | ThreeWidget | `wigglystuff.three_widget.ThreeWidget` | `data`, `width`, `height`, `show_grid`, `show_axes`, `dark_mode`, `axis_labels`, `animate_updates`, `animation_duration_ms` | 3D scatter plot for point clouds |
 | WebcamCapture | `wigglystuff.webcam_capture.WebcamCapture` | `image_base64`, `capturing`, `interval_ms`, `facing_mode` | Webcam preview with snapshot capture |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `Excalidraw.save()` now remembers the path and can be called with no argument. Widgets created with `Excalidraw.from_file(...)` capture their source path, so a bare `save()` writes back to the file they were loaded from; passing a path saves there and remembers it for subsequent bare calls. `save()` now returns the absolute destination (shown as the cell output in marimo) so it's always clear where the file landed. The widget still never writes on its own — drop `save()` into its own marimo cell and marimo re-runs it whenever the widget changes, so the file tracks what you draw. There is no file-watching or bidirectional sync; the notebook stays the source of truth.
+
 ### Changed
 
 - Docs: every widget's reference example now shows the marimo idiom `mo.ui.anywidget(...)` (wrapping the widget so its state syncs reactively in marimo), matching how the `demos/` notebooks use these widgets. The examples are auto-generated from class docstrings, so the rendered reference pages stay in sync.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.5.9] - 2026-06-08
 
 ### Added
 

--- a/demos/celltour.py
+++ b/demos/celltour.py
@@ -4,7 +4,7 @@
 #     "anywidget==0.9.21",
 #     "marimo>=0.23",
 #     "numpy==2.3.5",
-#     "wigglystuff==0.3.1",
+#     "wigglystuff==0.5.9",
 # ]
 # ///
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.8"
+version = "0.5.9"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_excalidraw.py
+++ b/tests/test_excalidraw.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from wigglystuff import Excalidraw
 
 SCENE = {
@@ -37,3 +39,27 @@ def test_save_and_from_file_round_trip(tmp_path):
     loaded = Excalidraw.from_file(path, height=300)
     assert loaded.scene == SCENE
     assert loaded.height == 300
+
+
+def test_save_remembers_path(tmp_path):
+    """save() remembers the path (from from_file or its own arg) and reuses it."""
+    src = tmp_path / "a.excalidraw"
+    Excalidraw(scene=SCENE).save(src)
+
+    # Loaded widget knows where it came from; bare save() writes back there.
+    loaded = Excalidraw.from_file(src)
+    assert loaded.source_path == src
+    loaded.scene = {**SCENE, "elements": []}
+    assert loaded.save() == src.resolve()
+    assert json.loads(src.read_text()) == {**SCENE, "elements": []}
+
+    # Passing a path writes there and is remembered for later bare calls.
+    other = tmp_path / "b.excalidraw"
+    loaded.save(other)
+    assert loaded.source_path == other
+    assert loaded.save() == other.resolve()
+    assert json.loads(other.read_text()) == {**SCENE, "elements": []}
+
+    # No path and never loaded -> clear error.
+    with pytest.raises(ValueError):
+        Excalidraw(scene=SCENE).save()

--- a/uv.lock
+++ b/uv.lock
@@ -3780,7 +3780,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.5.8"
+version = "0.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/excalidraw.py
+++ b/wigglystuff/excalidraw.py
@@ -38,6 +38,8 @@ class Excalidraw(anywidget.AnyWidget):
         ```python
         draw.save("diagram.excalidraw")          # write to disk
         again = Excalidraw.from_file("diagram.excalidraw")  # load it back
+        again.save()                              # write back to diagram.excalidraw
+        again.save("other.excalidraw")            # save elsewhere (and remember it)
         ```
     """
 
@@ -64,6 +66,7 @@ class Excalidraw(anywidget.AnyWidget):
         self.height = height
         self.sync_throttle_ms = sync_throttle_ms
         self.theme = theme
+        self.source_path: Optional[Path] = None
         if scene is not None:
             self.scene = scene
 
@@ -96,12 +99,37 @@ class Excalidraw(anywidget.AnyWidget):
         """Return the current scene serialized as a JSON string."""
         return json.dumps(self.scene)
 
-    def save(self, path: Union[str, Path]) -> None:
-        """Write the current scene to ``path`` as a ``.excalidraw`` JSON file."""
-        Path(path).write_text(self.to_json(), encoding="utf-8")
+    def save(self, path: Optional[Union[str, Path]] = None) -> Path:
+        """Write the current scene to a ``.excalidraw`` JSON file and return where.
+
+        Pass ``path`` to choose the destination; it is remembered on
+        ``source_path``, so later calls — and widgets created via
+        :meth:`from_file` — can call ``save()`` with no argument to write back
+        to the same file. This widget never writes on its own: in marimo,
+        putting ``save()`` in its own cell makes it *effectively* autosave,
+        because marimo (not this method) re-runs that cell whenever the widget
+        changes, so the file tracks what you draw. The returned absolute path is
+        shown as the cell output, so it is always clear which file was written.
+        """
+        if path is not None:
+            self.source_path = Path(path)
+        if self.source_path is None:
+            raise ValueError(
+                "save() needs a path: either pass one, e.g. "
+                'save("diagram.excalidraw"), or create the widget with '
+                "Excalidraw.from_file(...) so the source path is known."
+            )
+        Path(self.source_path).write_text(self.to_json(), encoding="utf-8")
+        return Path(self.source_path).resolve()
 
     @classmethod
     def from_file(cls, path: Union[str, Path], **kwargs) -> "Excalidraw":
-        """Create an :class:`Excalidraw` preloaded with the scene at ``path``."""
+        """Create an :class:`Excalidraw` preloaded with the scene at ``path``.
+
+        The path is remembered on ``source_path`` so you can call
+        :meth:`save` with no argument to write edits back to the same file.
+        """
         scene = json.loads(Path(path).read_text(encoding="utf-8"))
-        return cls(scene=scene, **kwargs)
+        widget = cls(scene=scene, **kwargs)
+        widget.source_path = Path(path)
+        return widget


### PR DESCRIPTION
Resolves #248. `Excalidraw.save(path)` now records the path (and `from_file()` captures it), so a bare `save()` writes back to the file the widget was loaded from; passing a path saves there and remembers it, and `save()` returns the absolute destination so it's clear where the file landed. There's deliberately no file-watching or autosave magic — in marimo, dropping `save()` in its own cell makes the reactive re-run persist edits. This also cuts the 0.5.9 release: the changelog is finalized (bundling the already-merged docs `mo.ui.anywidget` idiom and CellTour app-mode entries), the version is bumped in `pyproject.toml`/`uv.lock`, and the stale `wigglystuff==0.3.1` pin in `demos/celltour.py` is bumped to `0.5.9` (it was reworked this cycle and predates CellTour). New `test_save_remembers_path` covers the round-trip, path memory, and the no-path `ValueError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)