### PR TITLE
auto-size canvas with initial content

### DIFF
--- a/js/excalidraw/widget.js
+++ b/js/excalidraw/widget.js
@@ -145,14 +145,42 @@ function makeApp(React, Excalidraw, serializeAsJSON, exportToBlob, model, el) {
       }
     }, [dark]);
 
+    const refresh = () => apiRef.current && apiRef.current.refresh();
+
     // Excalidraw maps pointer -> canvas using its container's position, which it
     // measures on mount. In a notebook the widget sits well down the page, so
     // that initial measurement is stale and drawings land offset from the
     // cursor. refresh() recomputes it; re-run on scroll/resize (capture: true so
     // we catch the notebook's own scroll container, not just window).
     React.useEffect(() => {
-      const refresh = () => apiRef.current && apiRef.current.refresh();
       const t = setTimeout(refresh, 100);
+      window.addEventListener("scroll", refresh, true);
+      window.addEventListener("resize", refresh);
+      return () => {
+        clearTimeout(t);
+        window.removeEventListener("scroll", refresh, true);
+        window.removeEventListener("resize", refresh);
+      };
+    }, []);
+
+
+    React.useEffect(() => {
+      const t = setTimeout(() => {
+        if (apiRef.current) {
+          apiRef.current.refresh();
+    
+          // Scroll/zoom to fit all elements, capped at 100%
+          const elements = apiRef.current.getSceneElements();
+          if (elements.length > 0) {
+            apiRef.current.scrollToContent(elements, {
+              fitToContent: true,
+              viewportZoomFactor: 1,   // max 100% — won't zoom *in* beyond this
+              animate: false,
+            });
+          }
+        }
+      }, 100);
+    
       window.addEventListener("scroll", refresh, true);
       window.addEventListener("resize", refresh);
       return () => {


### PR DESCRIPTION
Implemented by IA, tested quickly. seems to work

By error, I opened the PR on my own repository, which makes very little sense :clown_face: 

So here we go again.

Closes #251 

# What it solves:

I create a big, zoomed-out drawing:

<img width="971" height="692" alt="image" src="https://github.com/user-attachments/assets/d36c4644-f4b7-48e6-9162-645e706152f0" />

I save, reload, and then I see

<img width="981" height="691" alt="image" src="https://github.com/user-attachments/assets/0639f6fa-c34b-4985-b68f-f451aaba7b45" />


But I would prefer the drawing to open with the correct scale and translation by default.

This PR does exactly that

---

Btw, I noticed that Excalidraw(path) on a non-existing path throws an error, which defeats the whole point of having an autosave feature. At least there should be a `create` flag.

