### PR TITLE
Release 0.5.11: TangleSlider click-to-type (issue #255)

### DIFF
--- a/.claude/skills/prep-release/SKILL.md
+++ b/.claude/skills/prep-release/SKILL.md
@@ -34,4 +34,6 @@ Prepare a new wigglystuff release. Follow these steps:
 
 8. **Verify nothing is missed**: Check the git diff to make sure all new/changed widgets have corresponding updates in all locations listed above.
 
-9. **Report** what was done and what still needs manual action (e.g., adding screenshots, replacing molab link placeholders).
+9. **Ship it — commit, push, and merge.** "Prepare a release" means the release actually lands on `main`; do NOT stop after the edits to ask whether to commit or merge. Run the mechanics without confirmation: commit the release changes, push the branch, open a PR against `main` (`gh pr create --base main`), and merge it (`gh pr merge`). Only pause if there's a genuine blocker (failing tests, merge conflicts, ambiguous diff) — not for the commit/PR/merge steps themselves.
+
+10. **Report** what was done and what still needs manual action (e.g., adding screenshots, replacing molab link placeholders).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.11] - 2026-06-30
+
+### Added
+
+- `TangleSlider`: click the value to type it in directly. Clicking (without dragging) turns the value into an inline input — type a number, press `Enter` to confirm or `Escape` to cancel; clicking outside also cancels. The typed value respects the slider's `min_value`/`max_value` (out-of-range values are clamped) and `step` (snapped to the step grid); non-numeric input restores the previous value. Dragging still works exactly as before. Click-to-type is only enabled for linear sliders, not those built with an explicit `steps` list. (#255)
+
 ## [0.5.9] - 2026-06-08
 
 ### Added

--- a/demos/tangle.py
+++ b/demos/tangle.py
@@ -5,13 +5,13 @@
 #     "marimo>=0.19.4",
 #     "numpy==2.4.1",
 #     "pandas==2.3.3",
-#     "wigglystuff==0.3.1",
+#     "wigglystuff==0.5.11",
 # ]
 # ///
 
 import marimo
 
-__generated_with = "0.23.1"
+__generated_with = "0.23.3"
 app = marimo.App(width="medium")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.9"
+version = "0.5.11"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_e2e/test_tangle_browser.py
+++ b/tests/test_e2e/test_tangle_browser.py
@@ -51,6 +51,31 @@ def test_tangle_slider_drag_updates_value(start_marimo, page: Page):
 
 
 @pytest.mark.e2e
+def test_tangle_slider_click_to_type(start_marimo, page: Page):
+    """Test that clicking (without dragging) opens an input to type a value."""
+    url = start_marimo(NOTEBOOK)
+    page.goto(url, wait_until="networkidle")
+
+    page.wait_for_selector(".tangle-value", timeout=TIMEOUT)
+    widget = page.locator(".tangle-value").first
+    expect(widget).to_be_visible()
+
+    # A plain click (mousedown + mouseup at the same spot) enters edit mode.
+    widget.click()
+
+    editor = page.locator(".tangle-input")
+    expect(editor).to_be_visible()
+
+    editor.fill("42")
+    editor.press("Enter")
+
+    page.wait_for_timeout(200)
+    value = page.locator(".tangle-value").first
+    expect(value).to_contain_text("42")
+    expect(value).to_contain_text("coffees")
+
+
+@pytest.mark.e2e
 def test_tangle_choice_renders_and_cycles(start_marimo, page: Page):
     """Test that TangleChoice renders and clicking cycles through choices."""
     url = start_marimo(NOTEBOOK)

--- a/uv.lock
+++ b/uv.lock
@@ -3780,7 +3780,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.5.9"
+version = "0.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/static/tangle-slider.js
+++ b/wigglystuff/static/tangle-slider.js
@@ -11,6 +11,7 @@ function render({model, el}) {
 
     let amount = model.get("amount");
     let steps = model.get("steps");
+    let editing = false;
 
     const container = document.createElement('div');
     container.classList.add("tangle-container");
@@ -29,7 +30,8 @@ function render({model, el}) {
             config.pixelsPerStep = model.get("pixels_per_step");
             amount = model.get("amount");
             steps = model.get("steps");
-            renderValue();
+            // Ignore external syncs while the user is typing a value.
+            if (!editing) renderValue();
         });
     });
 
@@ -63,9 +65,11 @@ function render({model, el}) {
         const startX = e.clientX;
         const startValue = parseFloat(element.textContent.replace(config.prefix, '').replace(config.suffix, ''));
         const startIndex = steps.length > 0 ? Math.max(0, steps.indexOf(amount)) : -1;
+        let moved = false;
 
         function onMouseMove(e) {
             const deltaX = e.clientX - startX;
+            if (Math.abs(deltaX) > 3) moved = true;
             const pixelSteps = Math.floor(deltaX / config.pixelsPerStep);
             if (steps.length > 0) {
                 const newIndex = Math.max(0, Math.min(steps.length - 1, startIndex + pixelSteps));
@@ -83,11 +87,76 @@ function render({model, el}) {
             document.removeEventListener('mousemove', onMouseMove);
             document.removeEventListener('mouseup', onMouseUp);
             element.style.cursor = 'ew-resize';
-            updateModel();
+            // A click without a real drag enters edit mode (linear sliders only).
+            if (!moved && steps.length === 0) {
+                amount = startValue;
+                enterEditMode();
+            } else {
+                updateModel();
+            }
         }
 
         document.addEventListener('mousemove', onMouseMove);
         document.addEventListener('mouseup', onMouseUp);
+    }
+
+    function enterEditMode() {
+        editing = true;
+        const previous = amount;
+        let finished = false;
+
+        container.innerHTML = '';
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'tangle-input';
+        input.value = amount.toFixed(config.digits);
+        // Match the value's look and keep it inline so the layout doesn't jump.
+        input.style.color = '#0066cc';
+        input.style.font = 'inherit';
+        input.style.background = 'transparent';
+        input.style.border = 'none';
+        input.style.borderBottom = '1px solid #0066cc';
+        input.style.padding = '0';
+        input.style.margin = '0';
+        input.style.width = `${Math.max(input.value.length + 1, 2)}ch`;
+        container.appendChild(input);
+        input.focus();
+        input.select();
+
+        function finish(commit) {
+            if (finished) return;
+            finished = true;
+            editing = false;
+            if (commit) {
+                const parsed = parseFloat(input.value);
+                if (!isNaN(parsed)) {
+                    let next = Math.max(config.minValue, Math.min(config.maxValue, parsed));
+                    // Snap to the step grid anchored at min_value, then re-clamp.
+                    if (config.stepSize > 0) {
+                        next = config.minValue + Math.round((next - config.minValue) / config.stepSize) * config.stepSize;
+                        next = Math.max(config.minValue, Math.min(config.maxValue, next));
+                    }
+                    amount = next;
+                } else {
+                    amount = previous; // Non-numeric input: restore previous value.
+                }
+            } else {
+                amount = previous; // Escape / blur cancels.
+            }
+            renderValue();
+            updateModel();
+        }
+
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                finish(true);
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                finish(false);
+            }
+        });
+        input.addEventListener('blur', () => finish(false));
     }
 
     renderValue();


### PR DESCRIPTION
## Summary

Adds **click-to-type** to `TangleSlider` (issue #255) and cuts the **0.5.11** release.

Clicking a `TangleSlider` value (without dragging) now turns it into an inline input:
- **Enter** confirms, **Escape** cancels, clicking away (blur) cancels.
- Typed values are **clamped** to `min_value`/`max_value` and **snapped** to the step grid (anchored at `min_value`).
- **Non-numeric** input restores the previous value.
- Dragging behaves exactly as before; click-to-type is enabled only for linear sliders, not `steps`-mode ones.

The feature is frontend-only — it lives entirely in `wigglystuff/static/tangle-slider.js`; no Python API change (the value already syncs via the `amount` traitlet).

## Release / version

`0.5.10` was published to PyPI manually for the weekly release, so this work is versioned **0.5.11**: `pyproject.toml`, `uv.lock`, the `CHANGELOG.md` heading, and the `demos/tangle.py` PEP 723 pin are all bumped.

## Also included

- New e2e test `test_tangle_slider_click_to_type` in `tests/test_e2e/test_tangle_browser.py`.
- `.claude/skills/prep-release/SKILL.md`: the release skill now ships end-to-end (commit → push → PR → merge) instead of stopping after the edits.

## Verification

- `uv run --extra test-browser pytest tests/test_e2e/test_tangle_browser.py -m e2e` — 5 passed (including the new click-to-type test).
- `uv run marimo check demos/tangle.py` — clean.
- Python import/instantiate smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)