### PR TITLE
Fix LiveEdit scroll: keep function visible while trace scrolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `LiveEdit`: the source and trace columns now scroll independently inside a
+  fixed-height box, so the function stays visible while a long trace scrolls on
+  the right (previously the whole widget scrolled as one unit and the source
+  scrolled out of view). The default height now auto-fits the function's line
+  count with a 520px floor, and an explicit `height=` is honored as a hard box
+  size.
+
 ## [0.5.12] - 2026-07-06
 
 ### Added

--- a/demos/liveedit.py
+++ b/demos/liveedit.py
@@ -127,7 +127,7 @@ def _(LiveEdit):
         return guess
 
 
-    LiveEdit.inspect_run(sqrt_newton, 30, steps=5)
+    LiveEdit.inspect_run(sqrt_newton, 30, steps=15)
     return
 
 

--- a/tests/test_live_edit.py
+++ b/tests/test_live_edit.py
@@ -130,6 +130,21 @@ def test_retrace_reports_argument_mismatch_without_crashing():
     assert widget.trace["returned"] is None
 
 
+def test_default_height_fits_source_with_floor():
+    short = LiveEdit("def f(x):\n    return x\n")
+    assert short.height == 520
+
+    long_source = (
+        "def f(x):\n"
+        + "\n".join(f"    x += {i}" for i in range(60))
+        + "\n    return x\n"
+    )
+    tall = LiveEdit(long_source)
+    assert tall.height > 520
+
+    assert LiveEdit(long_source, height=300).height == 300
+
+
 def test_module_level_inspect_run_alias():
     from wigglystuff import LiveEdit as RootLiveEdit
     from wigglystuff import inspect_run as root_inspect_run

--- a/wigglystuff/live_edit.py
+++ b/wigglystuff/live_edit.py
@@ -721,6 +721,7 @@ class LiveEdit(anywidget.AnyWidget):
         editable: bool = False,
         function_name: str | None = None,
         globalns: dict[str, Any] | None = None,
+        height: int | None = None,
         **widget_kwargs: Any,
     ) -> None:
         self._liveedit_args = tuple(args)
@@ -734,12 +735,20 @@ class LiveEdit(anywidget.AnyWidget):
             function_name=function_name,
             globalns=self._liveedit_globalns,
         )
+        if height is None:
+            # Fit the source by default: ~21px per rendered line (13px font *
+            # 1.55 line-height) plus top/bottom padding, floored at 520px so the
+            # trace panel keeps a roomy scroll area. Lines never wrap (they sit
+            # in an overflow-x panel), so a line-count estimate is accurate.
+            n_lines = len(code.splitlines()) or 1
+            height = max(520, n_lines * 21 + 40)
         super().__init__(
             code=code,
             trace=trace,
             annotations=annotations,
             error=error,
             editable=editable,
+            height=height,
             **widget_kwargs,
         )
 

--- a/wigglystuff/static/liveedit.css
+++ b/wigglystuff/static/liveedit.css
@@ -52,6 +52,8 @@
   border-radius: 8px;
   display: grid;
   grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  height: var(--liveedit-height);
   overflow: hidden;
 }
 
@@ -60,6 +62,7 @@
   font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
   font-size: 13px;
   line-height: 1.55;
+  min-height: 0;
   min-width: 0;
   padding: 16px 18px;
 }
@@ -67,12 +70,12 @@
 .liveedit-code {
   background: var(--liveedit-panel);
   border-right: 1px solid var(--liveedit-border);
-  overflow-x: auto;
+  overflow: auto;
 }
 
 .liveedit-trace {
   background: var(--liveedit-card);
-  overflow-x: auto;
+  overflow: auto;
 }
 
 .liveedit-line {
@@ -280,6 +283,14 @@
 @media (max-width: 760px) {
   .liveedit-card {
     grid-template-columns: 1fr;
+    grid-template-rows: none;
+    height: auto;
+  }
+
+  .liveedit-code,
+  .liveedit-trace {
+    overflow-x: auto;
+    overflow-y: visible;
   }
 
   .liveedit-code {

--- a/wigglystuff/static/liveedit.js
+++ b/wigglystuff/static/liveedit.js
@@ -226,7 +226,7 @@ function draw({ model, root }) {
   root.className = "liveedit-root";
   root.dataset.theme = model.get("theme") || "auto";
   root.style.width = `${model.get("width")}px`;
-  root.style.maxHeight = `${model.get("height")}px`;
+  root.style.setProperty("--liveedit-height", `${model.get("height")}px`);
 
   const card = document.createElement("div");
   card.className = "liveedit-card";


### PR DESCRIPTION
The `LiveEdit` source and trace columns previously scrolled as one unit, so scrolling a long trace pushed the source function out of view. This makes the two columns scroll independently inside a fixed-height box, keeping the function visible while the trace scrolls on the right (and letting a long function scroll in its own column). The default height now auto-fits the function's line count with a 520px floor, while an explicit `height=` is honored as a hard box size. Adds a height-default test and a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)