### PR TITLE
Render rich HTML reprs in the LiveEdit trace panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `LiveEdit`: trace values with a rich HTML representation now render inline in the trace panel instead of their plain `repr`. Setup variables, loop-pass cells, and the return value each check the value for marimo's `_display_`/`_mime_` protocols and IPython's `_repr_html_` (duck-typed, so no hard dependency on marimo/pandas/numpy) and, when found, render the HTML in the widget. Values without a rich representation are unchanged. Oversized payloads (>100 KB) fall back to `repr`.
+
 ## [0.5.12] - 2026-07-06
 
 ### Added

--- a/demos/liveedit.py
+++ b/demos/liveedit.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "anywidget",
+#     "dicekit",
 #     "drawdata",
 #     "marimo",
 #     "wigglystuff==0.5.12",
@@ -10,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.23.13"
+__generated_with = "0.23.3"
 app = marimo.App(width="full")
 
 
@@ -128,6 +129,80 @@ def _(LiveEdit):
 
 
     LiveEdit.inspect_run(sqrt_newton, 30, steps=5)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Rich HTML values
+
+    When a traced value exposes a rich representation (`_repr_html_`, marimo's
+    `_mime_`/`_display_`), the trace panel renders that HTML inline instead of
+    the plain `repr`. Any value assigned to a variable or returned shows up —
+    no `print` needed.
+    """)
+    return
+
+
+@app.cell
+def _(LiveEdit):
+    class Bar:
+        """A value whose HTML repr is a little colored bar."""
+
+        def __init__(self, value):
+            self.value = value
+
+        def __repr__(self):
+            return f"Bar({self.value})"
+
+        def _repr_html_(self):
+            width = min(self.value, 100)
+            return (
+                '<div style="display:flex;align-items:center;gap:6px">'
+                f'<div style="background:#0969da;height:14px;'
+                f'border-radius:3px;width:{width}px"></div>'
+                f"<span>{self.value}</span>"
+                "</div>"
+            )
+
+    def running_totals(steps):
+        total = 0
+        bar = Bar(0)
+        for step in steps:
+            total = total + step
+            bar = Bar(total)
+        return bar
+
+    LiveEdit.inspect_run(running_totals, [10, 15, 30, 25])
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ### Real-world showcase: `dicekit`
+
+    A [`dicekit`](https://github.com/koaning/dicekit) `Dice` has a boring
+    `repr` (just an object address) but a rich `_repr_html_` that draws its
+    probability distribution. As we add dice together, the trace shows the
+    running distribution chart for every pass — no `print`, just plain
+    assignments.
+    """)
+    return
+
+
+@app.cell
+def _(LiveEdit):
+    from dicekit import Dice
+
+    def sum_of_dice(n):
+        total = Dice.from_sides(6)
+        for _ in range(n - 1):
+            total = total + total
+        return total
+
+    LiveEdit.inspect_run(sum_of_dice, 8)
     return
 
 

--- a/tests/test_live_edit.py
+++ b/tests/test_live_edit.py
@@ -164,6 +164,80 @@ def test_repr_snapshots_for_in_place_mutation():
     ]
 
 
+class _HtmlCell:
+    def __init__(self, n):
+        self.n = n
+
+    def __repr__(self):
+        return f"Cell({self.n})"
+
+    def _repr_html_(self):
+        return f"<b>cell {self.n}</b>"
+
+
+class _MimeSummary:
+    def __init__(self, total):
+        self.total = total
+
+    def __repr__(self):
+        return f"Summary({self.total})"
+
+    def _mime_(self):
+        return ("text/html", f"<div>total={self.total}</div>")
+
+
+class _Displayable:
+    def __repr__(self):
+        return "Displayable()"
+
+    def _display_(self):
+        return _HtmlCell(99)
+
+
+def test_rich_html_captured_for_setup_and_return():
+    def build(x):
+        summary = _MimeSummary(x.n)
+        return summary
+
+    widget = LiveEdit.inspect_run(build, _HtmlCell(7))
+
+    setup = {item["name"]: item for item in widget.trace["setup"]}
+    assert setup["x"]["html"] == "<b>cell 7</b>"
+    assert setup["summary"]["html"] == "<div>total=7</div>"
+    assert widget.trace["returned"] == {
+        "repr": "Summary(7)",
+        "html": "<div>total=7</div>",
+    }
+
+
+def test_rich_html_captured_in_loop_cells_and_display_protocol():
+    def scan(cells):
+        marker = _Displayable()
+        for cell in cells:
+            marker = cell
+        return marker
+
+    widget = LiveEdit.inspect_run(scan, [_HtmlCell(1), _HtmlCell(2)])
+
+    assert widget.trace["setup"][-1]["html"] == "<b>cell 99</b>"  # _display_ path
+    loop = widget.trace["body"][0]
+    assert [p["cells_html"]["cell"] for p in loop["passes"]] == [
+        "<b>cell 1</b>",
+        "<b>cell 2</b>",
+    ]
+
+
+def test_plain_values_stay_repr_only():
+    def add(a, b):
+        total = a + b
+        return total
+
+    widget = LiveEdit.inspect_run(add, 2, 3)
+
+    assert all("html" not in item for item in widget.trace["setup"])
+    assert widget.trace["returned"] == {"repr": "5"}
+
+
 def test_auto_theme_follows_notebook_not_os_preference():
     css = Path("wigglystuff/static/liveedit.css").read_text()
 

--- a/wigglystuff/live_edit.py
+++ b/wigglystuff/live_edit.py
@@ -45,6 +45,52 @@ def _error_payload(exc: BaseException) -> dict[str, Any]:
     return payload
 
 
+_MAX_HTML_BYTES = 100_000  # skip giant payloads; fall back to repr
+
+
+def _html_from_mime(mime: str, data: Any) -> str | None:
+    if mime == "text/html" and isinstance(data, str):
+        return data
+    if mime.startswith("image/") and isinstance(data, str):
+        # marimo hands back either a data URL or bare base64; normalize to a URL.
+        src = data if data.startswith("data:") else f"data:{mime};base64,{data}"
+        return f'<img src="{src}" alt="" />'
+    return None
+
+
+def _render_html(value: Any) -> str | None:
+    """Best-effort rich HTML for a value, mirroring marimo's precedence.
+
+    Detects (in order) marimo's ``_display_``/``_mime_`` protocols and the
+    IPython ``_repr_html_`` protocol by duck typing, so no optional dependency
+    (marimo, pandas, numpy) needs to be importable. Returns ``None`` whenever
+    the value has no rich representation, rendering fails, or the payload is
+    larger than ``_MAX_HTML_BYTES`` (the caller then falls back to ``repr``).
+    """
+    html: str | None = None
+    try:
+        display = getattr(value, "_display_", None)
+        if callable(display):
+            html = _render_html(display())
+        if html is None:
+            mime = getattr(value, "_mime_", None)
+            if callable(mime):
+                mimetype, data = mime()
+                html = _html_from_mime(mimetype, data)
+        if html is None:
+            repr_html = getattr(value, "_repr_html_", None)
+            if callable(repr_html):
+                result = repr_html()
+                html = result if isinstance(result, str) else None
+    except Exception:  # noqa: BLE001 - rich rendering is best-effort, never fatal.
+        return None
+    if html is None or not html.strip():
+        return None
+    if len(html.encode("utf-8", "replace")) > _MAX_HTML_BYTES:
+        return None
+    return html
+
+
 def _clear_trace() -> dict[str, Any]:
     return {"setup": [], "body": [], "returned": None}
 
@@ -92,7 +138,9 @@ class _Collector:
         self.loop_meta = loop_meta
         self.setup_order: list[str] = []
         self.setup_values: dict[str, str] = {}
+        self.setup_html: dict[str, str] = {}
         self.global_values: dict[str, str] = {}
+        self.global_html: dict[str, str] = {}
         self.body: list[dict[str, Any]] = []
         self.loop_stack: list[str] = []
         self.pass_stack: list[dict[str, Any]] = []
@@ -101,7 +149,7 @@ class _Collector:
 
     def record_iter(self, loop_id: str) -> None:
         instance = self._loop_instance(loop_id)
-        pass_record = {"cells": {}, "changed": [], "children": []}
+        pass_record = {"cells": {}, "cells_html": {}, "changed": [], "children": []}
         pass_record["_instance"] = instance
         instance["passes"].append(pass_record)
         self.pending_passes[loop_id] = pass_record
@@ -115,16 +163,26 @@ class _Collector:
             return
         pass_record = self.pass_stack[-1]
         pass_record["_snapshot"] = dict(self.global_values)
+        pass_record["_snapshot_html"] = dict(self.global_html)
         self.loop_stack.pop()
         self.pass_stack.pop()
 
     def record_assign(self, name: str, value: Any, lineno: int) -> None:
         value_repr = repr(value)
+        value_html = _render_html(value)
         self.global_values[name] = value_repr
+        if value_html is not None:
+            self.global_html[name] = value_html
+        else:
+            self.global_html.pop(name, None)
         if not self.loop_stack:
             if name not in self.setup_order:
                 self.setup_order.append(name)
             self.setup_values[name] = value_repr
+            if value_html is not None:
+                self.setup_html[name] = value_html
+            else:
+                self.setup_html.pop(name, None)
             return
 
         pass_record = self.pass_stack[-1]
@@ -134,6 +192,8 @@ class _Collector:
         if name not in instance["_assignment_order"]:
             instance["_assignment_order"].append(name)
         pass_record["cells"][name] = value_repr
+        if value_html is not None:
+            pass_record["cells_html"][name] = value_html
         if name not in pass_record["changed"]:
             pass_record["changed"].append(name)
 
@@ -143,18 +203,27 @@ class _Collector:
 
     def record_return(self, value: Any, lineno: int) -> Any:
         self.returned = {"repr": repr(value)}
+        value_html = _render_html(value)
+        if value_html is not None:
+            self.returned["html"] = value_html
         return value
 
     def trace(self) -> dict[str, Any]:
         return {
             "setup": [
-                {"name": name, "repr": self.setup_values[name]}
+                self._setup_entry(name)
                 for name in self.setup_order
                 if name in self.setup_values
             ],
             "body": [self._serialize_loop(loop) for loop in self.body],
             "returned": self.returned,
         }
+
+    def _setup_entry(self, name: str) -> dict[str, Any]:
+        entry = {"name": name, "repr": self.setup_values[name]}
+        if name in self.setup_html:
+            entry["html"] = self.setup_html[name]
+        return entry
 
     def _loop_instance(self, loop_id: str) -> dict[str, Any]:
         container = self.pass_stack[-1]["children"] if self.pass_stack else self.body
@@ -187,21 +256,29 @@ class _Collector:
         passes = []
         for pass_record in loop["passes"]:
             snapshot = pass_record.get("_snapshot", {})
+            snapshot_html = pass_record.get("_snapshot_html", {})
             cells = {
                 name: pass_record["cells"].get(name, snapshot.get(name, ""))
                 for name in columns
                 if name in pass_record["cells"] or name in snapshot
             }
-            passes.append(
-                {
-                    "cells": cells,
-                    "changed": list(pass_record["changed"]),
-                    "children": [
-                        self._serialize_loop(child)
-                        for child in pass_record["children"]
-                    ],
-                }
-            )
+            cells_html = {}
+            for name in columns:
+                if name in pass_record["cells_html"]:
+                    cells_html[name] = pass_record["cells_html"][name]
+                elif name not in pass_record["cells"] and name in snapshot_html:
+                    cells_html[name] = snapshot_html[name]
+            entry = {
+                "cells": cells,
+                "changed": list(pass_record["changed"]),
+                "children": [
+                    self._serialize_loop(child)
+                    for child in pass_record["children"]
+                ],
+            }
+            if cells_html:
+                entry["cells_html"] = cells_html
+            passes.append(entry)
         return {
             "kind": "loop",
             "loop_id": loop["loop_id"],

--- a/wigglystuff/static/liveedit.css
+++ b/wigglystuff/static/liveedit.css
@@ -143,6 +143,31 @@
   color: var(--liveedit-code);
 }
 
+/* Rich HTML values: keep them scrollable and bounded so a DataFrame or figure
+   never overflows the panel. Applies to setup/return spans and loop cells. */
+.liveedit-value.liveedit-html,
+.liveedit-return-value.liveedit-html {
+  display: inline-block;
+  max-width: 100%;
+  max-height: 260px;
+  overflow: auto;
+  vertical-align: top;
+  white-space: normal;
+}
+
+td.liveedit-html {
+  max-width: 320px;
+  text-align: left;
+  white-space: normal;
+}
+
+.liveedit-html img,
+.liveedit-html svg,
+.liveedit-html table {
+  height: auto;
+  max-width: 100%;
+}
+
 .liveedit-loopblock {
   margin: 0 0 14px;
   padding: 8px 10px;

--- a/wigglystuff/static/liveedit.js
+++ b/wigglystuff/static/liveedit.js
@@ -9,6 +9,21 @@ function span(className, value) {
   return node;
 }
 
+// Render a value that may carry a rich HTML representation. Falls back to the
+// plain-text repr when no html is present. innerHTML does not execute <script>,
+// and the widget lives in a shadow root so styles stay isolated.
+function valueNode(className, reprValue, html) {
+  const node = document.createElement("span");
+  node.className = className;
+  if (html != null && html !== "") {
+    node.classList.add("liveedit-html");
+    node.innerHTML = html;
+  } else {
+    node.textContent = reprValue == null ? "" : String(reprValue);
+  }
+  return node;
+}
+
 function codeLine(line) {
   const row = document.createElement("div");
   row.className = "liveedit-line";
@@ -40,7 +55,7 @@ function kvRow(item) {
   row.title = item.repr;
   row.append(span("liveedit-kv-name", item.name.padEnd(6, " ")));
   row.append(text(" = "));
-  row.append(span("liveedit-value", item.repr));
+  row.append(valueNode("liveedit-value", item.repr, item.html));
   return row;
 }
 
@@ -53,7 +68,7 @@ function returnChip(returned) {
     return row;
   }
   row.textContent = "returned ";
-  const value = span("liveedit-return-value", returned.repr);
+  const value = valueNode("liveedit-return-value", returned.repr, returned.html);
   row.append(value);
   row.title = returned.repr;
   return row;
@@ -93,8 +108,15 @@ function tableForLoop(loop) {
     for (const column of loop.columns || []) {
       const cell = document.createElement("td");
       cell.dataset.var = column;
-      cell.textContent = pass.cells?.[column] ?? "";
-      cell.title = pass.cells?.[column] ?? "";
+      const reprValue = pass.cells?.[column] ?? "";
+      const html = pass.cells_html?.[column];
+      if (html != null && html !== "") {
+        cell.classList.add("liveedit-html");
+        cell.innerHTML = html;
+      } else {
+        cell.textContent = reprValue;
+      }
+      cell.title = reprValue;
       if ((pass.changed || []).includes(column)) {
         cell.classList.add("liveedit-changed");
       }


### PR DESCRIPTION
`LiveEdit` now detects a traced value's rich representation — marimo's `_display_`/`_mime_` protocols or IPython's `_repr_html_`, all duck-typed so no hard dependency on marimo/pandas/numpy is added — and renders that HTML inline in the trace panel for setup variables, loop-pass cells, and the return value, instead of the plain `repr`. Values without a rich representation are unchanged, and payloads over 100 KB fall back to `repr`. The frontend injects the HTML via `innerHTML` inside the widget's shadow root, with CSS bounding size/overflow so a chart or DataFrame can't blow out the panel. The demo notebook gains two showcases (a self-contained colored-`Bar` object and a `dicekit` `Dice` distribution chart), and tests cover the `_repr_html_`/`_mime_`/`_display_` paths plus the plain-value fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)