### PR TITLE
LiveEdit: anchor traced-run errors at the point of failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- `LiveEdit`: when a traced function raises, the failure is now anchored at the point where it happened instead of only floating in a summary box at the top. The failing source line is highlighted with an inline error message, the trace row (loop pass) where execution stopped is marked with a `✗`, and the return chip reads `raised <ErrorType>` rather than the misleading `returned None`. The compact top summary box is kept as well.
+
 ## [0.5.12] - 2026-07-06
 
 ### Added

--- a/demos/liveedit.py
+++ b/demos/liveedit.py
@@ -99,6 +99,35 @@ def _(LiveEdit):
     return
 
 
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    When a run raises, the trace stops at the failing pass. The failing source
+    line is highlighted with an inline message, the loop pass where execution
+    stopped is marked with a `✗`, and the widget reports `raised <ErrorType>`.
+    """)
+    return
+
+
+@app.cell
+def _(LiveEdit):
+    def insertion_sort_boom(values):
+        values = values[:]
+        for i in range(1, len(values)):
+            key = values[i]
+            j = i - 1
+            while j >= 0 and values[j] > key:
+                values[j + 1] = values[j]
+                j = j - 1
+            values[j + 1] = key
+        return values
+
+
+    # The trailing "a" makes `1 > "a"` raise a TypeError mid-run.
+    LiveEdit.inspect_run(insertion_sort_boom, [5, 2, 4, 3, 1, "a"])
+    return
+
+
 @app.cell
 def _(LiveEdit):
     def first_primes(limit):

--- a/tests/test_live_edit.py
+++ b/tests/test_live_edit.py
@@ -50,16 +50,19 @@ def test_inspect_run_traces_binary_search_top_to_bottom():
         {
             "cells": {"mid": "2", "value": "'c'", "low": "3", "high": "5"},
             "changed": ["mid", "value", "low"],
+            "failed": False,
             "children": [],
         },
         {
             "cells": {"mid": "4", "value": "'e'", "low": "3", "high": "3"},
             "changed": ["mid", "value", "high"],
+            "failed": False,
             "children": [],
         },
         {
             "cells": {"mid": "3", "value": "'d'", "low": "3", "high": "3"},
             "changed": ["mid", "value"],
+            "failed": False,
             "children": [],
         },
     ]
@@ -78,9 +81,9 @@ def test_nested_loops_attach_child_trace_to_outer_pass():
     first_inner = outer["passes"][0]["children"][0]
     assert first_inner["columns"] == ["c", "total"]
     assert first_inner["passes"] == [
-        {"cells": {"c": "0", "total": "0"}, "changed": ["c", "total"], "children": []},
-        {"cells": {"c": "1", "total": "1"}, "changed": ["c", "total"], "children": []},
-        {"cells": {"c": "2", "total": "3"}, "changed": ["c", "total"], "children": []},
+        {"cells": {"c": "0", "total": "0"}, "changed": ["c", "total"], "failed": False, "children": []},
+        {"cells": {"c": "1", "total": "1"}, "changed": ["c", "total"], "failed": False, "children": []},
+        {"cells": {"c": "2", "total": "3"}, "changed": ["c", "total"], "failed": False, "children": []},
     ]
 
     second_inner = outer["passes"][1]["children"][0]
@@ -128,6 +131,29 @@ def test_retrace_reports_argument_mismatch_without_crashing():
     assert widget.error["type"] == "TypeError"
     assert "arguments" in widget.error["message"]
     assert widget.trace["returned"] is None
+
+
+def insertion_sort(values):
+    values = values[:]
+    for i in range(1, len(values)):
+        key = values[i]
+        j = i - 1
+        while j >= 0 and values[j] > key:
+            values[j + 1] = values[j]
+            j = j - 1
+        values[j + 1] = key
+    return values
+
+
+def test_inspect_run_flags_failing_pass_and_line():
+    widget = LiveEdit.inspect_run(insertion_sort, [5, 2, 4, 3, 1, "a"])
+
+    assert widget.error["type"] == "TypeError"
+    assert widget.error["lineno"] == 6
+    assert widget.trace["returned"] is None
+
+    passes = widget.trace["body"][0]["passes"]
+    assert [p["failed"] for p in passes] == [False, False, False, False, True]
 
 
 def test_module_level_inspect_run_alias():

--- a/wigglystuff/live_edit.py
+++ b/wigglystuff/live_edit.py
@@ -4,6 +4,7 @@ import ast
 import inspect
 import io
 import keyword
+import sys
 import textwrap
 import tokenize
 import traceback
@@ -115,6 +116,10 @@ class _Collector:
             return
         pass_record = self.pass_stack[-1]
         pass_record["_snapshot"] = dict(self.global_values)
+        # exit_loop runs in the loop body's `finally`, so if an exception is
+        # unwinding through it right now this pass is on the failure path.
+        if sys.exc_info()[0] is not None:
+            pass_record["_failed"] = True
         self.loop_stack.pop()
         self.pass_stack.pop()
 
@@ -196,6 +201,7 @@ class _Collector:
                 {
                     "cells": cells,
                     "changed": list(pass_record["changed"]),
+                    "failed": pass_record.get("_failed", False),
                     "children": [
                         self._serialize_loop(child)
                         for child in pass_record["children"]

--- a/wigglystuff/static/liveedit.css
+++ b/wigglystuff/static/liveedit.css
@@ -17,6 +17,8 @@
   --liveedit-loop-rgb: 26, 127, 90;
   --liveedit-for: #0969da;
   --liveedit-while: #8250df;
+  --liveedit-error: #cf222e;
+  --liveedit-error-rgb: 207, 34, 46;
   color: var(--liveedit-code);
   color-scheme: light dark;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -44,6 +46,8 @@
   --liveedit-var-strong: rgba(245, 197, 24, 0.42);
   --liveedit-var-soft: rgba(245, 197, 24, 0.18);
   --liveedit-loop-rgb: 74, 222, 128;
+  --liveedit-error: #ff7b72;
+  --liveedit-error-rgb: 248, 81, 73;
 }
 
 .liveedit-card {
@@ -267,14 +271,44 @@
 }
 
 .liveedit-error {
-  background: rgba(207, 34, 46, 0.08);
-  border: 1px solid rgba(207, 34, 46, 0.28);
+  background: rgba(var(--liveedit-error-rgb), 0.08);
+  border: 1px solid rgba(var(--liveedit-error-rgb), 0.28);
   border-radius: 6px;
-  color: #cf222e;
+  color: var(--liveedit-error);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: 13px;
   margin-bottom: 14px;
   padding: 8px 10px;
+}
+
+.liveedit-line-error {
+  background: rgba(var(--liveedit-error-rgb), 0.1);
+  box-shadow: inset 3px 0 0 var(--liveedit-error);
+}
+
+.liveedit-inline-error {
+  color: var(--liveedit-error);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 12px;
+  padding: 2px 0 2px 12px;
+}
+
+.liveedit-pass-error > td {
+  background: rgba(var(--liveedit-error-rgb), 0.09);
+}
+
+.liveedit-pass-error > .liveedit-rowlabel {
+  box-shadow: inset 3px 0 0 var(--liveedit-error);
+  color: var(--liveedit-error);
+}
+
+.liveedit-return-raised {
+  color: var(--liveedit-error);
+}
+
+.liveedit-return-error {
+  color: var(--liveedit-error);
+  font-weight: 700;
 }
 
 @media (max-width: 760px) {

--- a/wigglystuff/static/liveedit.js
+++ b/wigglystuff/static/liveedit.js
@@ -44,10 +44,16 @@ function kvRow(item) {
   return row;
 }
 
-function returnChip(returned) {
+function returnChip(returned, error) {
   const row = document.createElement("div");
   row.className = "liveedit-return";
   if (!returned) {
+    if (error) {
+      row.classList.add("liveedit-return-raised");
+      row.textContent = "raised ";
+      row.append(span("liveedit-return-error", error.type));
+      return row;
+    }
     row.textContent = "returned ";
     row.append(span("liveedit-muted", "None"));
     return row;
@@ -85,9 +91,10 @@ function tableForLoop(loop) {
   (loop.passes || []).forEach((pass, index) => {
     const row = document.createElement("tr");
     row.dataset.hover = `loop:${loop.loop_id}`;
+    if (pass.failed) row.classList.add("liveedit-pass-error");
     const label = document.createElement("td");
     label.className = "liveedit-rowlabel";
-    label.textContent = `pass ${index + 1}`;
+    label.textContent = pass.failed ? `✗ pass ${index + 1}` : `pass ${index + 1}`;
     row.append(label);
 
     for (const column of loop.columns || []) {
@@ -231,16 +238,30 @@ function draw({ model, root }) {
   const card = document.createElement("div");
   card.className = "liveedit-card";
 
+  const error = model.get("error");
+
   const codePanel = document.createElement("div");
   codePanel.className = "liveedit-code";
   const annotations = model.get("annotations") || { lines: [] };
+  const codeLines = [];
   for (const line of annotations.lines || []) {
-    codePanel.append(codeLine(line));
+    const row = codeLine(line);
+    codePanel.append(row);
+    codeLines.push(row);
+  }
+  if (error && error.lineno) {
+    const failingLine = codeLines[error.lineno - 1];
+    if (failingLine) {
+      failingLine.classList.add("liveedit-line-error");
+      const inline = document.createElement("div");
+      inline.className = "liveedit-inline-error";
+      inline.textContent = `${error.type}: ${error.message}`;
+      failingLine.after(inline);
+    }
   }
 
   const tracePanel = document.createElement("div");
   tracePanel.className = "liveedit-trace";
-  const error = model.get("error");
   if (error) {
     const errorBox = document.createElement("div");
     errorBox.className = "liveedit-error";
@@ -258,7 +279,7 @@ function draw({ model, root }) {
     tracePanel.append(loopBlock(loop));
   }
 
-  const returned = returnChip(trace.returned);
+  const returned = returnChip(trace.returned, error);
   if (trace.returned?.repr) {
     for (const line of annotations.lines || []) {
       for (const name of line.returns || []) {


### PR DESCRIPTION
When a function traced by `LiveEdit.inspect_run` raises partway through (e.g. `insertion_sort([5, 2, 4, 3, 1, "a"])` hitting `1 > "a"`), the failure is now anchored where it happened instead of only floating in a summary box at the top of the trace panel. The failing source line is highlighted with an inline error message, the loop pass where execution stopped is marked with a `✗`, and the return chip reads `raised <ErrorType>` rather than the misleading `returned None` — while the compact top summary box is kept as well. On the Python side, `exit_loop` runs in the loop body's `finally`, so it uses `sys.exc_info()` to flag the pass that was active during the exception unwind, and `_serialize_loop` emits a `failed` flag per pass. The frontend renders both anchors using light/dark CSS variables. Covered by a new test plus updated fixtures, and a new erroring-run cell in the demo notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)