### PR TITLE
Release 0.5.13: LiveEdit trace charts, float_precision, visible_columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ syncs back to Python.
 | GamepadWidget | `wigglystuff.gamepad.GamepadWidget` | `axes`, `current_button_press`, `dpad_*`, `current_timestamp` | Streams browser Gamepad API events |
 | HoverZoom | `wigglystuff.hover_zoom.HoverZoom` | `image`, `zoom_factor`, `width`, `height`, `_crop` | Image hover zoom with magnified side panel |
 | KeystrokeWidget | `wigglystuff.keystroke.KeystrokeWidget` | `last_key` | Captures the latest keypress w/ modifiers |
-| LiveEdit | `wigglystuff.live_edit.LiveEdit` | `code`, `trace`, `annotations`, `error`, `editable`, `theme`, `width`, `height` | Source-linked loop trace for inspecting one Python function run |
+| LiveEdit | `wigglystuff.live_edit.LiveEdit` | `code`, `trace`, `annotations`, `error`, `editable`, `theme`, `width`, `height`, `float_precision`, `visible_columns` | Source-linked loop trace for inspecting one Python function run; click numeric column headers to chart them |
 | WebkitSpeechToTextWidget | `wigglystuff.talk.WebkitSpeechToTextWidget` | `transcript`, `listening`, `trigger_listen` | WebKit speech recognition bridge |
 | DriverTour | `wigglystuff.driver_tour.DriverTour` | `steps`, `auto_start`, `show_progress`, `active`, `current_step` | Guided product tours via Driver.js |
 | CellTour | `wigglystuff.cell_tour.CellTour` | `steps`, `auto_start`, `show_progress`, `active`, `current_step` | Simplified cell-based tours for marimo |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.13] - 2026-07-06
+
+### Added
+
+- `LiveEdit`: click a numeric loop-trace column header to plot that variable across passes (iteration on X, value on Y) as an inline line chart. A plain click starts a fresh single-series chart; ⌘/Ctrl-click overlays a column onto the current chart (shared Y-axis); Shift-click stacks a new chart below, sharing the X-axis so panels at different scales line up by iteration. A small `×` clears the chart. Only columns whose every pass parses to a finite float are chartable, and charts render as lightweight SVG with no new dependencies.
+- `LiveEdit`: the widget now sizes to its content by default so wide tables and charts make the whole widget grow (and the host page/marimo scrolls), instead of a cramped scrollbar inside the widget. Set a positive `width`/`height` to cap a dimension and get an internal scrollbar for that axis.
+- `LiveEdit`: new `float_precision` argument (and traitlet) rounds float cells to the given number of significant figures to keep wide tables readable; charts keep full precision. Defaults to `None` (exact `repr`).
+- `LiveEdit`: new `visible_columns` argument (and traitlet) restricts the trace tables to a chosen subset of variables; the default empty list shows everything. Applied in the browser, so it updates without re-running the traced function.
+
 ## [0.5.12] - 2026-07-06
 
 ### Added

--- a/demos/liveedit.py
+++ b/demos/liveedit.py
@@ -4,6 +4,7 @@
 #     "anywidget",
 #     "drawdata",
 #     "marimo",
+#     "numpy",
 #     "wigglystuff==0.5.13",
 # ]
 # ///
@@ -137,6 +138,8 @@ def _(LiveEdit):
 
 @app.cell
 def _(LiveEdit):
+    import numpy as np
+
     def gradient_descent(start, steps=12):
         x = start
         lr = 0.4
@@ -144,7 +147,7 @@ def _(LiveEdit):
             grad = 2 * (x - 3)
             x = x - lr * grad
             loss = (x - 3) ** 2
-            lr = lr * 0.85
+            lr = np.sin(step * np.pi / steps) * lr + 0.1
         return x
 
 

--- a/demos/liveedit.py
+++ b/demos/liveedit.py
@@ -4,7 +4,7 @@
 #     "anywidget",
 #     "drawdata",
 #     "marimo",
-#     "wigglystuff==0.5.12",
+#     "wigglystuff==0.5.13",
 # ]
 # ///
 
@@ -37,7 +37,11 @@ def _(mo):
 
     `LiveEdit.inspect_run(...)` records one run of a Python function and shows
     how loop variables change pass by pass. Hover a variable or loop in either
-    panel to connect the code with the trace.
+    panel to connect the code with the trace. Click a numeric column header to
+    plot it across passes — plain click for a fresh chart, ⌘/Ctrl-click to
+    overlay on the same axes, Shift-click to stack a new chart below (shared
+    iteration axis). Pass `float_precision=` to trim wide float columns and
+    `visible_columns=` to show only the variables you care about.
     """)
     return
 
@@ -128,6 +132,31 @@ def _(LiveEdit):
 
 
     LiveEdit.inspect_run(sqrt_newton, 30, steps=5)
+    return
+
+
+@app.cell
+def _(LiveEdit):
+    def gradient_descent(start, steps=12):
+        x = start
+        lr = 0.4
+        for step in range(steps):
+            grad = 2 * (x - 3)
+            x = x - lr * grad
+            loss = (x - 3) ** 2
+            lr = lr * 0.85
+        return x
+
+
+    # `float_precision` keeps the table readable; charts still use full values.
+    # Click `loss` to watch it decay, then Shift-click `lr` to stack a second
+    # chart below it (same iteration axis, its own y-axis).
+    LiveEdit.inspect_run(gradient_descent, 12.0, steps=12, float_precision=4)
+    return
+
+
+@app.cell
+def _():
     return
 
 

--- a/demos/liveedit.py
+++ b/demos/liveedit.py
@@ -155,10 +155,5 @@ def _(LiveEdit):
     return
 
 
-@app.cell
-def _():
-    return
-
-
 if __name__ == "__main__":
     app.run()

--- a/docs/superpowers/specs/2026-07-06-liveedit-trace-charts-design.md
+++ b/docs/superpowers/specs/2026-07-06-liveedit-trace-charts-design.md
@@ -1,0 +1,135 @@
+# LiveEdit Trace Charts — Design Spec
+
+## Problem
+
+When tracing loops with `LiveEdit`, users can see per-pass values in a table
+but cannot easily visualise how variables change across iterations. Spotting
+convergence, oscillation, or trends requires mentally scanning many rows of
+repr strings.
+
+## Goal
+
+Let users select numeric column(s) in a loop's trace table and see an
+overlaid line chart — iteration on X, variable value on Y — rendered inline
+inside the widget. No re-tracing, no separate widget, no Python-roundtrip.
+
+## Design
+
+### Numeric detection (Python side)
+
+A new `numerics` dictionary is added to each serialized loop node in the
+trace. During collection, after each assignment the value is attempted via
+`float(value)` inside a try/except. The float or `None` is stored alongside
+the repr string in a `_numerics` dict on the pass record. During
+`_serialize_loop`, each column is checked: if every pass has a non-None
+float, the column appears in the `numerics` output dict.
+
+```python
+# added inside _serialize_loop, alongside columns/passes
+"numerics": {
+  "low":  [0, 3, 3, 4, 4],
+  "mid":  [2, 2, 3, 3, 4],
+  "high": [5, 5, 5, 5, 5],
+}
+```
+
+The `numerics` dict is built in `_serialize_loop` after all passes are
+assembled. For each column, if every pass has a stored numeric value (not
+None), it is included; otherwise the column is omitted.
+
+Only columns where **every pass** has a valid float are included. If a column
+appears in `numerics`, its header is clickable.
+
+### Column header click interaction (JS)
+
+- Numeric column headers (`<th>` elements) get `cursor: pointer` and a subtle
+  chart icon (SVG inline or unicode `📈`) visible on hover.
+- Click toggles selection: clicking a non-selected header adds it to the
+  loop's selected set; clicking a selected header removes it.
+- Zero selected = no chart rendered.
+- When a loop has selected columns, the loop block switches to a flexbox row
+  layout: `<table> | <chart-panel>`.
+
+### Chart rendering (JS)
+
+A lightweight SVG line chart is rendered in vanilla JS (no D3 dependency):
+
+- **Canvas size:** 280 × 180 px, inside a `<div class="liveedit-chart">`.
+- **Margins:** 10 px top, 10 px right, 20 px bottom (for X labels), 40 px left
+  (for Y labels).
+- **Axes:** `<path>` for X and Y baselines, tick marks at 4–6 intervals.
+- **Lines:** One `<path>` per selected column. Stroke color from a fixed
+  palette (blue, orange, green, red, purple, teal, pink).
+- **Y scale:** Auto-scaled from min/max across all selected columns, with
+  ~5 % padding.
+- **X scale:** Linear 0 to (n_passes - 1).
+- **Data points:** Small circles on each line at each pass.
+- **Tooltip:** Hovering near a data point shows a floating label with the
+  exact value.
+
+### Close/clear mechanism
+
+- Clicking a selected column header again deselects it (toggle).
+- A small "×" button in the top-right corner of the chart panel clears all
+  selections and hides the chart.
+- When the last selected column is deselected, the chart panel disappears.
+
+### Layout
+
+Per-loop block structure (before):
+
+```
+<div class="liveedit-loopblock">
+  <div class="liveedit-badgerow"> ... </div>
+  <table class="liveedit-table"> ... </table>
+</div>
+```
+
+Per-loop block structure (with chart):
+
+```
+<div class="liveedit-loopblock liveedit-loopblock-charting">
+  <div class="liveedit-badgerow"> ... </div>
+  <div class="liveedit-loopbody">
+    <table class="liveedit-table"> ... </table>
+    <div class="liveedit-chart">
+      <button class="liveedit-chart-close">×</button>
+      <svg ...> ... </svg>
+    </div>
+  </div>
+</div>
+```
+
+`.liveedit-loopbody` uses `display: flex; flex-direction: row; gap: 12px`.
+
+### Theming
+
+Chart colors, axis lines, and text follow existing CSS variables. New CSS
+custom properties on `.liveedit-root`:
+
+- `--liveedit-chart-line-0`, `--liveedit-chart-line-1`, etc. (stroke palette)
+- `--liveedit-chart-bg`: background of chart panel
+- `--liveedit-chart-axis`: stroke color for axes/grid
+
+### No Python API changes
+
+- `LiveEdit` class unchanged — no new traitlets, no new methods.
+- `_Collector` gains numeric recording but the change is internal only.
+- `trace` dict gains the `numerics` key on loop nodes; existing keys
+  (`columns`, `passes`) unchanged for backward compat.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `wigglystuff/live_edit.py` | `_Collector` stores float-parsed values; `_serialize_loop` emits `numerics` dict |
+| `wigglystuff/static/liveedit.js` | Column click toggles, SVG chart renderer, loop-block flex layout |
+| `wigglystuff/static/liveedit.css` | Chart panel styles, selected-column indicator, chart icon |
+
+## Non-goals
+
+- Editing or removing data points from within the chart.
+- Pan/zoom of chart.
+- Exporting chart as image.
+- Nested loop charting (out of scope for v1 — nested loop data is sparser and
+  harder to lay out).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.12"
+version = "0.5.13"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_live_edit.py
+++ b/tests/test_live_edit.py
@@ -164,6 +164,62 @@ def test_repr_snapshots_for_in_place_mutation():
     ]
 
 
+def test_numerics_include_only_all_numeric_columns():
+    widget = LiveEdit.inspect_run(binary_search, key="d", array=list("abcdef"))
+
+    numerics = widget.trace["body"][0]["numerics"]
+
+    # low/high/mid are numeric every pass; snapshot fallbacks stay numeric too.
+    assert numerics == {
+        "low": [3.0, 3.0, 3.0],
+        "high": [5.0, 3.0, 3.0],
+        "mid": [2.0, 4.0, 3.0],
+    }
+    # `value` holds strings ('c', 'e', 'd') so it is never chartable.
+    assert "value" not in numerics
+
+
+def test_numerics_emitted_for_nested_loops():
+    widget = LiveEdit.inspect_run(grid_sum, rows=2, cols=3)
+
+    inner = widget.trace["body"][0]["passes"][0]["children"][0]
+    assert inner["numerics"] == {"c": [0.0, 1.0, 2.0], "total": [0.0, 1.0, 3.0]}
+
+
+def test_float_precision_trims_floats_but_keeps_charts_and_ints_exact():
+    def sqrt_newton(x, steps=4):
+        guess = x / 2
+        for step in range(steps):
+            guess = 0.5 * (guess + x / guess)
+        return guess
+
+    widget = LiveEdit.inspect_run(sqrt_newton, 30, steps=4, float_precision=4)
+    loop = widget.trace["body"][0]
+
+    # Float cells rounded to 4 significant figures; the return chip too.
+    assert [pass_["cells"]["guess"] for pass_ in loop["passes"]] == [
+        "8.5",
+        "6.015",
+        "5.501",
+        "5.477",
+    ]
+    assert widget.trace["returned"] == {"repr": "5.477"}
+    # Charts keep full precision so plotted lines stay accurate.
+    assert loop["numerics"]["guess"][1] == 6.014705882352941
+    # Integer columns (step) are untouched by float rounding.
+    assert [pass_["cells"]["step"] for pass_ in loop["passes"]] == ["0", "1", "2", "3"]
+
+
+def test_visible_columns_defaults_to_show_all():
+    widget = LiveEdit.inspect_run(binary_search, key="d", array=list("abcdef"))
+    assert widget.visible_columns == []
+
+    widget = LiveEdit.inspect_run(
+        binary_search, key="d", array=list("abcdef"), visible_columns=["low", "high"]
+    )
+    assert widget.visible_columns == ["low", "high"]
+
+
 def test_auto_theme_follows_notebook_not_os_preference():
     css = Path("wigglystuff/static/liveedit.css").read_text()
 

--- a/uv.lock
+++ b/uv.lock
@@ -3780,7 +3780,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.5.12"
+version = "0.5.13"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/live_edit.py
+++ b/wigglystuff/live_edit.py
@@ -87,12 +87,35 @@ def _unique(items: list[str]) -> list[str]:
     return out
 
 
+def _as_float(value: Any) -> float | None:
+    """Return a plottable float for ``value`` or ``None`` when it is not one.
+
+    Booleans and non-finite floats (nan/inf) are treated as non-numeric so
+    they never end up as chart data.
+    """
+    if isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in (float("inf"), float("-inf")):
+        return None
+    return number
+
+
 class _Collector:
-    def __init__(self, loop_meta: dict[str, dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        loop_meta: dict[str, dict[str, Any]],
+        float_precision: int | None = None,
+    ) -> None:
         self.loop_meta = loop_meta
+        self.float_precision = float_precision
         self.setup_order: list[str] = []
         self.setup_values: dict[str, str] = {}
         self.global_values: dict[str, str] = {}
+        self.global_numerics: dict[str, float | None] = {}
         self.body: list[dict[str, Any]] = []
         self.loop_stack: list[str] = []
         self.pass_stack: list[dict[str, Any]] = []
@@ -101,7 +124,7 @@ class _Collector:
 
     def record_iter(self, loop_id: str) -> None:
         instance = self._loop_instance(loop_id)
-        pass_record = {"cells": {}, "changed": [], "children": []}
+        pass_record = {"cells": {}, "changed": [], "children": [], "_numerics": {}}
         pass_record["_instance"] = instance
         instance["passes"].append(pass_record)
         self.pending_passes[loop_id] = pass_record
@@ -115,12 +138,23 @@ class _Collector:
             return
         pass_record = self.pass_stack[-1]
         pass_record["_snapshot"] = dict(self.global_values)
+        pass_record["_snapshot_numerics"] = dict(self.global_numerics)
         self.loop_stack.pop()
         self.pass_stack.pop()
 
+    def _format_value(self, value: Any) -> str:
+        # Trim only float scalars (numpy floats subclass float); ints, strings,
+        # arrays, etc. keep their exact repr. Charts use the raw floats, so this
+        # affects the displayed table cells only.
+        if self.float_precision is not None and isinstance(value, float):
+            return f"{value:.{self.float_precision}g}"
+        return repr(value)
+
     def record_assign(self, name: str, value: Any, lineno: int) -> None:
-        value_repr = repr(value)
+        value_repr = self._format_value(value)
+        numeric = _as_float(value)
         self.global_values[name] = value_repr
+        self.global_numerics[name] = numeric
         if not self.loop_stack:
             if name not in self.setup_order:
                 self.setup_order.append(name)
@@ -134,6 +168,7 @@ class _Collector:
         if name not in instance["_assignment_order"]:
             instance["_assignment_order"].append(name)
         pass_record["cells"][name] = value_repr
+        pass_record["_numerics"][name] = numeric
         if name not in pass_record["changed"]:
             pass_record["changed"].append(name)
 
@@ -142,7 +177,7 @@ class _Collector:
         return value
 
     def record_return(self, value: Any, lineno: int) -> Any:
-        self.returned = {"repr": repr(value)}
+        self.returned = {"repr": self._format_value(value)}
         return value
 
     def trace(self) -> dict[str, Any]:
@@ -208,7 +243,30 @@ class _Collector:
             "loop_type": loop["loop_type"],
             "columns": columns,
             "passes": passes,
+            "numerics": self._numerics_for(loop, columns),
         }
+
+    def _numerics_for(
+        self, loop: dict[str, Any], columns: list[str]
+    ) -> dict[str, list[float]]:
+        numerics: dict[str, list[float]] = {}
+        for name in columns:
+            values: list[float] = []
+            for pass_record in loop["passes"]:
+                snapshot = pass_record.get("_snapshot_numerics", {})
+                pass_numerics = pass_record.get("_numerics", {})
+                if name in pass_numerics:
+                    value = pass_numerics[name]
+                elif name in snapshot:
+                    value = snapshot[name]
+                else:
+                    value = None
+                if value is None:
+                    break
+                values.append(value)
+            if len(values) == len(loop["passes"]) and values:
+                numerics[name] = values
+        return numerics
 
 
 class _Instrumenter(ast.NodeTransformer):
@@ -628,6 +686,7 @@ def _trace_code(
     *,
     function_name: str | None = None,
     globalns: dict[str, Any] | None = None,
+    float_precision: int | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any] | None]:
     kwargs = {} if kwargs is None else dict(kwargs)
     try:
@@ -643,7 +702,7 @@ def _trace_code(
     instrumenter = _Instrumenter(target_name)
     transformed = instrumenter.visit(tree)
     ast.fix_missing_locations(transformed)
-    collector = _Collector(instrumenter.loop_meta)
+    collector = _Collector(instrumenter.loop_meta, float_precision)
     namespace = dict(globalns or {})
     namespace.update(
         {
@@ -709,8 +768,16 @@ class LiveEdit(anywidget.AnyWidget):
     error = traitlets.Dict(default_value=None, allow_none=True).tag(sync=True)
     editable = traitlets.Bool(False).tag(sync=True)
     theme = traitlets.Unicode("auto").tag(sync=True)
-    width = traitlets.Int(900).tag(sync=True)
+    # width: 0 means "grow to fit content" (host page scrolls); a positive value
+    # caps the width and shows an internal horizontal scrollbar instead.
+    width = traitlets.Int(0).tag(sync=True)
     height = traitlets.Int(520).tag(sync=True)
+    # Round float cells to this many significant figures (None = exact repr).
+    # Applied Python-side; charts keep full precision.
+    float_precision = traitlets.Int(default_value=None, allow_none=True)
+    # Show only these variables in the trace tables (empty = show all). Applied
+    # in the browser, so it updates without re-running the function.
+    visible_columns = traitlets.List(traitlets.Unicode()).tag(sync=True)
 
     def __init__(
         self,
@@ -721,6 +788,8 @@ class LiveEdit(anywidget.AnyWidget):
         editable: bool = False,
         function_name: str | None = None,
         globalns: dict[str, Any] | None = None,
+        float_precision: int | None = None,
+        visible_columns: list[str] | None = None,
         **widget_kwargs: Any,
     ) -> None:
         self._liveedit_args = tuple(args)
@@ -733,6 +802,7 @@ class LiveEdit(anywidget.AnyWidget):
             self._liveedit_kwargs,
             function_name=function_name,
             globalns=self._liveedit_globalns,
+            float_precision=float_precision,
         )
         super().__init__(
             code=code,
@@ -740,24 +810,41 @@ class LiveEdit(anywidget.AnyWidget):
             annotations=annotations,
             error=error,
             editable=editable,
+            float_precision=float_precision,
+            visible_columns=list(visible_columns or []),
             **widget_kwargs,
         )
 
-    @traitlets.observe("code")
-    def _retrace(self, change: dict[str, Any]) -> None:
+    def _recompute(self, code: str) -> None:
         trace, annotations, error = _trace_code(
-            change["new"],
+            code,
             self._liveedit_args,
             self._liveedit_kwargs,
             function_name=self._liveedit_function_name,
             globalns=self._liveedit_globalns,
+            float_precision=self.float_precision,
         )
         self.trace = trace
         self.annotations = annotations
         self.error = error
 
+    @traitlets.observe("code")
+    def _retrace(self, change: dict[str, Any]) -> None:
+        self._recompute(change["new"])
+
+    @traitlets.observe("float_precision")
+    def _reformat(self, change: dict[str, Any]) -> None:
+        self._recompute(self.code)
+
     @classmethod
-    def inspect_run(cls, fn: Any, *args: Any, **kwargs: Any) -> "LiveEdit":
+    def inspect_run(
+        cls,
+        fn: Any,
+        *args: Any,
+        float_precision: int | None = None,
+        visible_columns: list[str] | None = None,
+        **kwargs: Any,
+    ) -> "LiveEdit":
         code, function_name, globalns = _source_for(fn)
         return cls(
             code,
@@ -766,6 +853,8 @@ class LiveEdit(anywidget.AnyWidget):
             editable=False,
             function_name=function_name,
             globalns=globalns,
+            float_precision=float_precision,
+            visible_columns=visible_columns,
         )
 
 

--- a/wigglystuff/static/liveedit.css
+++ b/wigglystuff/static/liveedit.css
@@ -17,11 +17,23 @@
   --liveedit-loop-rgb: 26, 127, 90;
   --liveedit-for: #0969da;
   --liveedit-while: #8250df;
+  --liveedit-chart-bg: #fbfbfd;
+  --liveedit-chart-axis: #b8b8c0;
+  --liveedit-chart-grid: #ececf0;
+  --liveedit-chart-line-0: #2563eb;
+  --liveedit-chart-line-1: #ea580c;
+  --liveedit-chart-line-2: #16a34a;
+  --liveedit-chart-line-3: #dc2626;
+  --liveedit-chart-line-4: #7c3aed;
+  --liveedit-chart-line-5: #0d9488;
+  --liveedit-chart-line-6: #db2777;
   color: var(--liveedit-code);
   color-scheme: light dark;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  max-width: 100%;
-  overflow: auto;
+  /* Size to content by default (see draw() in liveedit.js); a width/height cap
+     switches back to an internal scrollbar. */
+  width: max-content;
+  overflow: visible;
 }
 
 .liveedit-root[data-theme="dark"],
@@ -44,6 +56,16 @@
   --liveedit-var-strong: rgba(245, 197, 24, 0.42);
   --liveedit-var-soft: rgba(245, 197, 24, 0.18);
   --liveedit-loop-rgb: 74, 222, 128;
+  --liveedit-chart-bg: #202024;
+  --liveedit-chart-axis: #5a5a63;
+  --liveedit-chart-grid: #343439;
+  --liveedit-chart-line-0: #60a5fa;
+  --liveedit-chart-line-1: #fb923c;
+  --liveedit-chart-line-2: #4ade80;
+  --liveedit-chart-line-3: #f87171;
+  --liveedit-chart-line-4: #c4b5fd;
+  --liveedit-chart-line-5: #2dd4bf;
+  --liveedit-chart-line-6: #f472b6;
 }
 
 .liveedit-card {
@@ -51,7 +73,9 @@
   border: 1px solid var(--liveedit-border);
   border-radius: 8px;
   display: grid;
-  grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr);
+  /* Code panel is bounded (it scrolls its own long lines); the trace panel
+     grows to fit its table + chart so nothing scrolls inside the widget. */
+  grid-template-columns: minmax(300px, 520px) max-content;
   overflow: hidden;
 }
 
@@ -144,8 +168,13 @@
 }
 
 .liveedit-loopblock {
+  box-sizing: border-box;
   margin: 0 0 14px;
   padding: 8px 10px;
+  /* Grow to fit a wide table so the loop highlight covers all of it, but still
+     fill the panel when the table is narrow. */
+  min-width: 100%;
+  width: max-content;
 }
 
 .liveedit-loopblock-nested {
@@ -237,6 +266,161 @@
 .liveedit-col-active {
   background: var(--liveedit-var-soft) !important;
 }
+
+.liveedit-chart-col {
+  cursor: pointer;
+  user-select: none;
+}
+
+.liveedit-th-label {
+  vertical-align: middle;
+}
+
+.liveedit-chart-icon {
+  margin-left: 4px;
+  opacity: 0;
+  stroke: var(--liveedit-accent);
+  vertical-align: middle;
+}
+
+.liveedit-chart-col:hover .liveedit-chart-icon,
+.liveedit-chart-col-active .liveedit-chart-icon {
+  opacity: 0.85;
+}
+
+.liveedit-chart-col-active {
+  color: var(--liveedit-accent);
+}
+
+.liveedit-loopbody {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+}
+
+.liveedit-loopbody .liveedit-table {
+  width: auto;
+}
+
+.liveedit-chart {
+  background: var(--liveedit-chart-bg);
+  border: 1px solid var(--liveedit-border);
+  border-radius: 6px;
+  flex: 0 0 auto;
+  padding: 8px;
+  position: relative;
+}
+
+.liveedit-chart-close {
+  background: transparent;
+  border: none;
+  color: var(--liveedit-muted);
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+  padding: 2px 4px;
+  position: absolute;
+  right: 4px;
+  top: 4px;
+}
+
+.liveedit-chart-close:hover {
+  color: var(--liveedit-code);
+}
+
+.liveedit-chart-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.liveedit-chart-block:not(:last-child) {
+  border-bottom: 1px solid var(--liveedit-border);
+  padding-bottom: 8px;
+}
+
+.liveedit-chart-svg {
+  display: block;
+}
+
+.liveedit-chart-axis {
+  stroke: var(--liveedit-chart-axis);
+  stroke-width: 1;
+}
+
+.liveedit-chart-tick {
+  stroke: var(--liveedit-chart-axis);
+  stroke-width: 1;
+}
+
+.liveedit-chart-grid {
+  stroke: var(--liveedit-chart-grid);
+  stroke-width: 1;
+}
+
+.liveedit-chart-axis-label {
+  fill: var(--liveedit-muted);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 9px;
+}
+
+.liveedit-chart-line {
+  fill: none;
+  stroke-width: 1.75;
+}
+
+.liveedit-chart-dot {
+  stroke: var(--liveedit-chart-bg);
+  stroke-width: 1;
+}
+
+.liveedit-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  margin-top: 6px;
+}
+
+.liveedit-chart-legend-item {
+  font-size: 11px;
+  padding-left: 12px;
+  position: relative;
+}
+
+.liveedit-chart-legend-item::before {
+  border-radius: 2px;
+  content: "";
+  height: 8px;
+  left: 0;
+  position: absolute;
+  top: 3px;
+  width: 8px;
+}
+
+.liveedit-chart-stroke-0 { stroke: var(--liveedit-chart-line-0); }
+.liveedit-chart-stroke-1 { stroke: var(--liveedit-chart-line-1); }
+.liveedit-chart-stroke-2 { stroke: var(--liveedit-chart-line-2); }
+.liveedit-chart-stroke-3 { stroke: var(--liveedit-chart-line-3); }
+.liveedit-chart-stroke-4 { stroke: var(--liveedit-chart-line-4); }
+.liveedit-chart-stroke-5 { stroke: var(--liveedit-chart-line-5); }
+.liveedit-chart-stroke-6 { stroke: var(--liveedit-chart-line-6); }
+
+.liveedit-chart-fill-0 { fill: var(--liveedit-chart-line-0); }
+.liveedit-chart-fill-1 { fill: var(--liveedit-chart-line-1); }
+.liveedit-chart-fill-2 { fill: var(--liveedit-chart-line-2); }
+.liveedit-chart-fill-3 { fill: var(--liveedit-chart-line-3); }
+.liveedit-chart-fill-4 { fill: var(--liveedit-chart-line-4); }
+.liveedit-chart-fill-5 { fill: var(--liveedit-chart-line-5); }
+.liveedit-chart-fill-6 { fill: var(--liveedit-chart-line-6); }
+
+.liveedit-chart-swatch-0::before { background: var(--liveedit-chart-line-0); }
+.liveedit-chart-swatch-1::before { background: var(--liveedit-chart-line-1); }
+.liveedit-chart-swatch-2::before { background: var(--liveedit-chart-line-2); }
+.liveedit-chart-swatch-3::before { background: var(--liveedit-chart-line-3); }
+.liveedit-chart-swatch-4::before { background: var(--liveedit-chart-line-4); }
+.liveedit-chart-swatch-5::before { background: var(--liveedit-chart-line-5); }
+.liveedit-chart-swatch-6::before { background: var(--liveedit-chart-line-6); }
 
 .liveedit-child-cell {
   background: transparent !important;

--- a/wigglystuff/static/liveedit.js
+++ b/wigglystuff/static/liveedit.js
@@ -59,9 +59,37 @@ function returnChip(returned) {
   return row;
 }
 
-function tableForLoop(loop) {
+const CHART_PALETTE_SIZE = 7;
+
+function chartIcon() {
+  const svg = svgEl("svg", {
+    class: "liveedit-chart-icon",
+    viewBox: "0 0 16 16",
+    width: 12,
+    height: 12,
+  });
+  svg.append(
+    svgEl("polyline", {
+      points: "1,11 5,7 8,9 15,2",
+      fill: "none",
+      "stroke-width": 1.6,
+      "stroke-linecap": "round",
+      "stroke-linejoin": "round",
+    })
+  );
+  return svg;
+}
+
+function tableForLoop(loop, chartState, colVisible, nested) {
   const table = document.createElement("table");
   table.className = "liveedit-table";
+
+  const numerics = loop.numerics || {};
+  const cols = (loop.columns || []).filter(colVisible);
+  // chartState maps a loop id to an array of panels; each panel is an array of
+  // column names. A column is "active" if it appears in any panel.
+  const panels = chartState.get(loop.loop_id) || [];
+  const charted = new Set(panels.flat());
 
   const thead = document.createElement("thead");
   const header = document.createElement("tr");
@@ -69,10 +97,21 @@ function tableForLoop(loop) {
   const rowLabel = document.createElement("th");
   rowLabel.className = "liveedit-rowlabel";
   header.append(rowLabel);
-  for (const column of loop.columns || []) {
+  for (const column of cols) {
     const th = document.createElement("th");
-    th.textContent = column;
     th.dataset.var = column;
+    // Only top-level loops support charting (nested loop data is sparser).
+    if (!nested && numerics[column]) {
+      th.classList.add("liveedit-chart-col");
+      th.dataset.chartCol = column;
+      th.dataset.loop = loop.loop_id;
+      th.title = `Plot ${column} — ⌘/Ctrl-click to overlay, Shift-click to stack below`;
+      if (charted.has(column)) th.classList.add("liveedit-chart-col-active");
+      th.append(span("liveedit-th-label", column));
+      th.append(chartIcon());
+    } else {
+      th.textContent = column;
+    }
     header.append(th);
   }
   const spacer = document.createElement("th");
@@ -90,7 +129,7 @@ function tableForLoop(loop) {
     label.textContent = `pass ${index + 1}`;
     row.append(label);
 
-    for (const column of loop.columns || []) {
+    for (const column of cols) {
       const cell = document.createElement("td");
       cell.dataset.var = column;
       cell.textContent = pass.cells?.[column] ?? "";
@@ -109,10 +148,10 @@ function tableForLoop(loop) {
       const childRow = document.createElement("tr");
       childRow.className = "liveedit-child-row";
       const childCell = document.createElement("td");
-      childCell.colSpan = (loop.columns || []).length + 2;
+      childCell.colSpan = cols.length + 2;
       childCell.className = "liveedit-child-cell";
       for (const child of pass.children) {
-        childCell.append(loopBlock(child, true));
+        childCell.append(loopBlock(child, chartState, colVisible, true));
       }
       childRow.append(childCell);
       tbody.append(childRow);
@@ -122,7 +161,7 @@ function tableForLoop(loop) {
   return table;
 }
 
-function loopBlock(loop, nested = false) {
+function loopBlock(loop, chartState, colVisible, nested = false) {
   const block = document.createElement("div");
   block.className = nested ? "liveedit-loopblock liveedit-loopblock-nested" : "liveedit-loopblock";
   block.dataset.loop = loop.loop_id;
@@ -133,8 +172,215 @@ function loopBlock(loop, nested = false) {
   const badge = span(`liveedit-badge ${loop.loop_type === "for" ? "liveedit-for" : "liveedit-while"}`, `${loop.loop_type} loop`);
   badgeRow.append(badge);
   block.append(badgeRow);
-  block.append(tableForLoop(loop));
+
+  const table = tableForLoop(loop, chartState, colVisible, nested);
+  const numerics = loop.numerics || {};
+  const panels = chartState.get(loop.loop_id) || [];
+  // Keep only chartable, visible columns and drop panels that end up empty.
+  const activePanels = panels
+    .map((columns) => columns.filter((column) => numerics[column] && colVisible(column)))
+    .filter((columns) => columns.length);
+
+  if (!nested && activePanels.length) {
+    block.classList.add("liveedit-loopblock-charting");
+    const body = document.createElement("div");
+    body.className = "liveedit-loopbody";
+    body.append(table);
+    body.append(chartPanel(loop, activePanels));
+    block.append(body);
+  } else {
+    block.append(table);
+  }
   return block;
+}
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function svgEl(tag, attrs) {
+  const node = document.createElementNS(SVG_NS, tag);
+  for (const [key, value] of Object.entries(attrs || {})) {
+    node.setAttribute(key, String(value));
+  }
+  return node;
+}
+
+function formatTick(value) {
+  if (Number.isInteger(value)) return String(value);
+  const abs = Math.abs(value);
+  if (abs >= 100) return value.toFixed(0);
+  if (abs >= 1) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+function chartLegend(columns) {
+  const legend = document.createElement("div");
+  legend.className = "liveedit-chart-legend";
+  columns.forEach((column, index) => {
+    const item = document.createElement("span");
+    item.className = `liveedit-chart-legend-item liveedit-chart-swatch-${index % CHART_PALETTE_SIZE}`;
+    item.textContent = column;
+    legend.append(item);
+  });
+  return legend;
+}
+
+function chartPanel(loop, activePanels) {
+  const panel = document.createElement("div");
+  panel.className = "liveedit-chart";
+
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "liveedit-chart-close";
+  close.dataset.loop = loop.loop_id;
+  close.textContent = "×";
+  close.title = "Clear chart";
+  panel.append(close);
+
+  // One chart per panel, stacked vertically. They share the X pixel mapping, so
+  // iterations line up; only the bottom panel labels the shared X-axis.
+  const stack = document.createElement("div");
+  stack.className = "liveedit-chart-stack";
+  activePanels.forEach((columns, index) => {
+    const block = document.createElement("div");
+    block.className = "liveedit-chart-block";
+    block.append(chartSvg(loop, columns, index === activePanels.length - 1));
+    block.append(chartLegend(columns));
+    stack.append(block);
+  });
+  panel.append(stack);
+  return panel;
+}
+
+function chartSvg(loop, columns, showX) {
+  const width = 280;
+  const margin = { top: 10, right: 10, bottom: 22, left: 40 };
+  const plotWidth = width - margin.left - margin.right;
+  const plotHeight = 110;
+  const height = margin.top + plotHeight + margin.bottom;
+
+  const series = columns.map((column) => loop.numerics[column]);
+  const passCount = series[0].length;
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const values of series) {
+    for (const value of values) {
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    min = 0;
+    max = 1;
+  }
+  if (min === max) {
+    min -= 1;
+    max += 1;
+  }
+  const yPad = (max - min) * 0.05;
+  min -= yPad;
+  max += yPad;
+
+  const xFor = (index) =>
+    margin.left + (passCount <= 1 ? plotWidth / 2 : (index / (passCount - 1)) * plotWidth);
+  const yFor = (value) =>
+    margin.top + plotHeight - ((value - min) / (max - min)) * plotHeight;
+
+  const svg = svgEl("svg", {
+    class: "liveedit-chart-svg",
+    width,
+    height,
+    viewBox: `0 0 ${width} ${height}`,
+  });
+
+  const baseY = margin.top + plotHeight;
+  const baseX = margin.left;
+
+  // Y ticks + gridlines.
+  const yTicks = 5;
+  for (let i = 0; i < yTicks; i++) {
+    const value = min + (i / (yTicks - 1)) * (max - min);
+    const y = yFor(value);
+    svg.append(
+      svgEl("line", {
+        class: "liveedit-chart-grid",
+        x1: baseX,
+        y1: y,
+        x2: baseX + plotWidth,
+        y2: y,
+      })
+    );
+    const label = svgEl("text", {
+      class: "liveedit-chart-axis-label",
+      x: baseX - 5,
+      y: y + 3,
+      "text-anchor": "end",
+    });
+    label.textContent = formatTick(value);
+    svg.append(label);
+  }
+
+  // X ticks: one per pass, thinned to at most 6 labels. Only the bottom panel
+  // in a stack labels the shared X-axis to keep the others compact.
+  if (showX) {
+    const stride = Math.max(1, Math.ceil(passCount / 6));
+    for (let i = 0; i < passCount; i++) {
+      if (i % stride !== 0 && i !== passCount - 1) continue;
+      const x = xFor(i);
+      svg.append(
+        svgEl("line", {
+          class: "liveedit-chart-tick",
+          x1: x,
+          y1: baseY,
+          x2: x,
+          y2: baseY + 3,
+        })
+      );
+      const label = svgEl("text", {
+        class: "liveedit-chart-axis-label",
+        x,
+        y: baseY + 14,
+        "text-anchor": "middle",
+      });
+      label.textContent = String(i + 1);
+      svg.append(label);
+    }
+  }
+
+  // Axis baselines.
+  svg.append(
+    svgEl("line", { class: "liveedit-chart-axis", x1: baseX, y1: margin.top, x2: baseX, y2: baseY })
+  );
+  svg.append(
+    svgEl("line", { class: "liveedit-chart-axis", x1: baseX, y1: baseY, x2: baseX + plotWidth, y2: baseY })
+  );
+
+  // One line + points per selected column.
+  series.forEach((values, seriesIndex) => {
+    const paletteIndex = seriesIndex % CHART_PALETTE_SIZE;
+    const points = values.map((value, index) => `${xFor(index)},${yFor(value)}`).join(" ");
+    svg.append(
+      svgEl("polyline", {
+        class: `liveedit-chart-line liveedit-chart-stroke-${paletteIndex}`,
+        points,
+        fill: "none",
+      })
+    );
+    values.forEach((value, index) => {
+      const dot = svgEl("circle", {
+        class: `liveedit-chart-dot liveedit-chart-fill-${paletteIndex}`,
+        cx: xFor(index),
+        cy: yFor(value),
+        r: 2.5,
+      });
+      const title = svgEl("title", {});
+      title.textContent = `${columns[seriesIndex]} · pass ${index + 1} = ${formatTick(value)}`;
+      dot.append(title);
+      svg.append(dot);
+    });
+  });
+
+  return svg;
 }
 
 function clearAll(root) {
@@ -221,12 +467,18 @@ function applyHover(root, target) {
   }
 }
 
-function draw({ model, root }) {
+function draw({ model, root, chartState }) {
   root.innerHTML = "";
   root.className = "liveedit-root";
   root.dataset.theme = model.get("theme") || "auto";
-  root.style.width = `${model.get("width")}px`;
-  root.style.maxHeight = `${model.get("height")}px`;
+  // By default the widget sizes to its content and the host page scrolls; a
+  // positive width/height turns that axis back into an internal scrollbar.
+  const widthCap = model.get("width");
+  const heightCap = model.get("height");
+  root.style.width = "max-content";
+  root.style.maxWidth = widthCap > 0 ? `${widthCap}px` : "none";
+  root.style.maxHeight = heightCap > 0 ? `${heightCap}px` : "none";
+  root.style.overflow = widthCap > 0 || heightCap > 0 ? "auto" : "visible";
 
   const card = document.createElement("div");
   card.className = "liveedit-card";
@@ -254,8 +506,12 @@ function draw({ model, root }) {
   for (const item of trace.setup || []) setup.append(kvRow(item));
   tracePanel.append(setup);
 
+  // Empty visible_columns means "show everything".
+  const visible = new Set(model.get("visible_columns") || []);
+  const colVisible = (column) => visible.size === 0 || visible.has(column);
+
   for (const loop of trace.body || []) {
-    tracePanel.append(loopBlock(loop));
+    tracePanel.append(loopBlock(loop, chartState, colVisible));
   }
 
   const returned = returnChip(trace.returned);
@@ -278,8 +534,33 @@ function draw({ model, root }) {
 function render({ model, el }) {
   const root = document.createElement("div");
   el.append(root);
-  const redraw = () => draw({ model, root });
+  // loop_id -> Set of column names the user selected for charting.
+  const chartState = new Map();
+  const redraw = () => draw({ model, root, chartState });
   redraw();
+
+  // A full redraw rebuilds the DOM, which resets scroll. Preserve the scroll
+  // position of the panels so toggling a chart doesn't jump the view.
+  const redrawKeepingScroll = () => {
+    const selectors = [".liveedit-trace", ".liveedit-code"];
+    const saved = selectors.map((selector) => {
+      const el = root.querySelector(selector);
+      return el ? { selector, left: el.scrollLeft, top: el.scrollTop } : null;
+    });
+    const rootLeft = root.scrollLeft;
+    const rootTop = root.scrollTop;
+    redraw();
+    root.scrollLeft = rootLeft;
+    root.scrollTop = rootTop;
+    for (const entry of saved) {
+      if (!entry) continue;
+      const el = root.querySelector(entry.selector);
+      if (el) {
+        el.scrollLeft = entry.left;
+        el.scrollTop = entry.top;
+      }
+    }
+  };
 
   root.addEventListener("mouseover", (event) => {
     clearAll(root);
@@ -287,7 +568,50 @@ function render({ model, el }) {
   });
   root.addEventListener("mouseleave", () => clearAll(root));
 
-  ["code", "trace", "annotations", "error", "theme", "width", "height"].forEach((name) => {
+  root.addEventListener("click", (event) => {
+    const header = event.target.closest("th[data-chart-col]");
+    if (header) {
+      const loopId = header.dataset.loop;
+      const column = header.dataset.chartCol;
+      const panels = (chartState.get(loopId) || []).map((columns) => [...columns]);
+      if (event.shiftKey) {
+        // Shift-click: add a new chart stacked below, sharing the X-axis.
+        panels.push([column]);
+      } else if (event.metaKey || event.ctrlKey) {
+        // ⌘/Ctrl-click: overlay onto the current (bottom) chart, shared Y-axis.
+        const last = panels[panels.length - 1];
+        if (!last) {
+          panels.push([column]);
+        } else {
+          const at = last.indexOf(column);
+          if (at >= 0) last.splice(at, 1);
+          else last.push(column);
+          if (!last.length) panels.pop();
+        }
+      } else {
+        // Plain click: one fresh single-series chart (toggles off if it's the
+        // only series currently shown).
+        const isSole =
+          panels.length === 1 && panels[0].length === 1 && panels[0][0] === column;
+        panels.length = 0;
+        if (!isSole) panels.push([column]);
+      }
+      if (panels.length) chartState.set(loopId, panels);
+      else chartState.delete(loopId);
+      redrawKeepingScroll();
+      return;
+    }
+    const close = event.target.closest(".liveedit-chart-close");
+    if (close) {
+      chartState.delete(close.dataset.loop);
+      redrawKeepingScroll();
+    }
+  });
+
+  // Editing code changes loop ids/columns, so drop selections that no longer apply.
+  model.on("change:trace", () => chartState.clear());
+
+  ["code", "trace", "annotations", "error", "theme", "width", "height", "visible_columns"].forEach((name) => {
     model.on(`change:${name}`, redraw);
   });
 }


### PR DESCRIPTION
Ships the 0.5.13 release built around `LiveEdit` loop-trace charts: clicking a numeric column header plots that variable across passes as an inline SVG chart, with plain click for a fresh chart, ⌘/Ctrl-click to overlay on a shared Y-axis, and Shift-click to stack a new chart below sharing the X-axis. Adds two config options exposed as both `inspect_run`/constructor kwargs and traitlets: `float_precision` (rounds float table cells to N significant figures while charts keep full precision) and `visible_columns` (restricts the tables to a chosen subset of variables). The widget now sizes to its content by default so wide tables/charts grow and the host page (marimo) scrolls, instead of a cramped internal scrollbar — a positive `width`/`height` caps that axis. Python-side numeric detection emits a per-loop `numerics` dict with no breaking changes to existing trace keys. Also bumps the version to 0.5.13 (`pyproject.toml`, `CHANGELOG.md`, demo pin), adds focused tests, a `gradient_descent` demo cell, and the design spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
