### PR TITLE
Fix stale test_liveedit_demo after LiveEdit demo rewrite

### DIFF
--- a/tests/test_liveedit_demo.py
+++ b/tests/test_liveedit_demo.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
 
-def test_liveedit_demo_replaces_grid_sum_with_algorithm_sampler():
+def test_liveedit_demo_wires_functions_through_inspect_run():
     source = Path("demos/liveedit.py").read_text()
 
     assert "grid_sum" not in source
-    for name in ["gcd", "insertion_sort", "first_primes", "sqrt_newton"]:
+    for name in ["gcd", "insertion_sort", "binary_search", "gradient_descent"]:
         assert f"def {name}" in source
         assert f"LiveEdit.inspect_run({name}" in source
 


### PR DESCRIPTION
The `tests` CI job was failing because `tests/test_liveedit_demo.py` still asserted the old demo functions (`first_primes`, `sqrt_newton`), which PR #270 removed when it rewrote `demos/liveedit.py`. This updates the assertions to a stable subset that exists in the current demo (`gcd`, `insertion_sort`, `binary_search`, `gradient_descent`) and renames the test to reflect its intent. The `grid_sum` absence check is preserved. Verified with `uv run pytest --ignore=tests/test_e2e` (244 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)