### PR TITLE
Release 0.5.14: ParallelCoordinates controls/labels polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.5.14] - 2026-07-14
 
 ### Changed
 

--- a/demos/liveedit.py
+++ b/demos/liveedit.py
@@ -6,7 +6,7 @@
 #     "drawdata",
 #     "marimo",
 #     "numpy",
-#     "wigglystuff==0.5.13",
+#     "wigglystuff==0.5.14",
 # ]
 # ///
 

--- a/demos/parallelcoords.py
+++ b/demos/parallelcoords.py
@@ -5,7 +5,7 @@
 #     "numpy",
 #     "polars",
 #     "scikit-learn",
-#     "wigglystuff==0.3.1",
+#     "wigglystuff==0.5.14",
 # ]
 # ///
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.13"
+version = "0.5.14"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Patch release `0.5.13 → 0.5.14`. No new widgets — the only user-facing change is the `ParallelCoordinates` controls/labels polish (#272), already curated in the changelog's `Unreleased` section.

- Bump `pyproject.toml` version to `0.5.14`
- Promote `## [Unreleased]` → `## [0.5.14] - 2026-07-14` in `CHANGELOG.md`
- Refresh `wigglystuff==` pins to `0.5.14` in the demos touched this release (`demos/parallelcoords.py`, `demos/liveedit.py`)

Core dependencies verified clean (no 3rd-party leak; `neo4j` stays under optional extras).

🤖 Generated with [Claude Code](https://claude.com/claude-code)