### PR TITLE
Release 0.5.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.5.16] - 2026-07-14
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.15"
+version = "0.5.16"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3202,7 +3202,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.5.15"
+version = "0.5.16"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
Cuts the **0.5.16** release, bundling three widgets that landed since `v0.5.15`:

- **AsyncFlow** (#277, #280) — live swimlane timeline of one async run
- **FramePlayer** (#279) — play a sequence of images as a looping video
- **ManimWeb** (#278) — run a browser-Manim scene inline

### Changes
- `pyproject.toml`: `0.5.15` → `0.5.16` (+ matching `uv.lock`)
- `CHANGELOG.md`: renamed `## [Unreleased]` → `## [0.5.16] - 2026-07-14`

All doc locations (README gallery, `docs/index.md`, `docs/llms.txt`, reference
pages, `zensical.toml` nav, `CLAUDE.md` quick-reference, gallery screenshots) and
the demo `wigglystuff==0.5.16` pins were already in place from the feature PRs, so
this PR is just the version cut. README table double-checked — complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)