### PR TITLE
Fix FramePlayer playback stutter (#289); release 0.5.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.18] - 2026-07-15
+
+### Fixed
+
+- `FramePlayer`: playback no longer stutters or flips frames out of order over a remote kernel (MoLab/sandbox). Playback and scrubbing are now fully client-side — the widget advances a local frame counter instead of round-tripping the synced `value` traitlet to the kernel on every frame, which previously created a feedback loop of out-of-order comm messages that painted stale frames. Behavior note: `value` and `playing` are now one-way Python→JS controls (setting `player.value = 10` or `player.playing = True` still drives the widget), but the widget no longer reports the live playhead or the play/pause state back to Python. Fixes #289.
+
 ## [0.5.17] - 2026-07-15
 
 ### Added

--- a/demos/frame_player.py
+++ b/demos/frame_player.py
@@ -5,7 +5,7 @@
 #     "matplotlib",
 #     "numpy",
 #     "pillow",
-#     "wigglystuff==0.5.16",
+#     "wigglystuff==0.5.18",
 # ]
 # ///
 
@@ -67,14 +67,6 @@ def _(FramePlayer, make_frames, mo):
     )
     player
     return (player,)
-
-
-@app.cell(hide_code=True)
-def _(mo, player):
-    mo.md(f"""
-    Currently showing frame **{player.value.get('value', 0)}**.
-    """)
-    return
 
 
 @app.cell(hide_code=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.17"
+version = "0.5.18"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3202,7 +3202,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.5.17"
+version = "0.5.18"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/wigglystuff/static/frame-player.js
+++ b/wigglystuff/static/frame-player.js
@@ -32,10 +32,17 @@ function render({ model, el }) {
   el.appendChild(wrapper);
 
   let intervalId = null;
-  let localUpdate = false;
+  // Local frame index — the single source of truth for what's displayed.
+  // Playback is purely client-side; the widget never writes state back to the
+  // kernel, so there is no comm round-trip per frame and nothing to echo.
+  let cur = 0;
 
   function maxIndex() {
     return Math.max(0, model.get("frames").length - 1);
+  }
+
+  function clampIndex(i) {
+    return Math.max(0, Math.min(i, maxIndex()));
   }
 
   function applyWidth() {
@@ -65,7 +72,7 @@ function render({ model, el }) {
 
   function renderFrame() {
     const frames = model.get("frames");
-    const idx = Math.max(0, Math.min(model.get("value"), maxIndex()));
+    const idx = clampIndex(cur);
     if (frames.length > 0) {
       image.src = frames[idx];
     } else {
@@ -78,98 +85,82 @@ function render({ model, el }) {
   }
 
   function renderBtn() {
-    btn.innerHTML = model.get("playing") ? PAUSE_ICON : PLAY_ICON;
+    btn.innerHTML = intervalId !== null ? PAUSE_ICON : PLAY_ICON;
   }
 
   function tick() {
     const max = maxIndex();
-    let val = model.get("value") + 1;
+    let next = cur + 1;
 
-    if (val > max) {
+    if (next > max) {
       if (model.get("loop")) {
-        val = 0;
+        next = 0;
       } else {
-        val = max;
         stopPlaying();
+        return;
       }
     }
 
-    localUpdate = true;
-    model.set("value", val);
-    model.save_changes();
+    cur = next;
+    renderFrame();
   }
 
   function startPlaying() {
     if (intervalId !== null) return;
-    const ms = model.get("interval_ms");
-    intervalId = setInterval(tick, ms);
-    localUpdate = true;
-    model.set("playing", true);
-    model.save_changes();
+    intervalId = setInterval(tick, model.get("interval_ms"));
     renderBtn();
   }
 
   function stopPlaying() {
-    if (intervalId !== null) {
-      clearInterval(intervalId);
-      intervalId = null;
-    }
-    localUpdate = true;
-    model.set("playing", false);
-    model.save_changes();
+    if (intervalId === null) return;
+    clearInterval(intervalId);
+    intervalId = null;
     renderBtn();
   }
 
   // Button click toggles play/pause
   btn.addEventListener("click", () => {
-    if (model.get("playing")) {
+    if (intervalId !== null) {
       stopPlaying();
     } else {
       startPlaying();
     }
   });
 
-  // Manual scrubbing
+  // Manual scrubbing — moves the local playhead; playback (if running)
+  // continues from the new position.
   slider.addEventListener("input", () => {
-    localUpdate = true;
-    model.set("value", parseInt(slider.value, 10));
-    model.save_changes();
+    cur = clampIndex(parseInt(slider.value, 10));
     renderFrame();
   });
 
-  // React to Python-side value changes
+  // Python can jump the frame by setting `value` (Python -> JS control).
   model.on("change:value", () => {
+    cur = clampIndex(model.get("value"));
     renderFrame();
-    if (!localUpdate) {
-      model.save_changes();
-    }
-    localUpdate = false;
   });
 
-  // React to Python toggling playing
+  // Python can start/stop playback by setting `playing` (Python -> JS control).
   model.on("change:playing", () => {
-    const playing = model.get("playing");
-    if (playing && intervalId === null) {
+    if (model.get("playing")) {
       startPlaying();
-    } else if (!playing && intervalId !== null) {
+    } else {
       stopPlaying();
     }
-    renderBtn();
-    localUpdate = false;
   });
 
   // React to interval_ms change while playing
   model.on("change:interval_ms", () => {
     if (intervalId !== null) {
       clearInterval(intervalId);
-      const ms = model.get("interval_ms");
-      intervalId = setInterval(tick, ms);
+      intervalId = setInterval(tick, model.get("interval_ms"));
     }
   });
 
   // React to a new frame sequence
   model.on("change:frames", () => {
     syncSliderAttrs();
+    cur = clampIndex(cur);
     renderFrame();
   });
 
@@ -179,7 +170,9 @@ function render({ model, el }) {
   // Initial render
   applyWidth();
   syncSliderAttrs();
+  cur = clampIndex(model.get("value"));
   renderFrame();
+  if (model.get("playing")) startPlaying();
   renderBtn();
 
   // Cleanup


### PR DESCRIPTION
Fixes #289. `FramePlayer` playback stuttered and flipped frames out of order over a remote kernel because `tick()` round-tripped the synced `value` traitlet to the kernel on every frame and `renderFrame()` painted whatever (often out-of-order) value the kernel echoed back. Playback and scrubbing are now fully client-side — the widget advances a local frame counter and never calls `save_changes()`, so latency can't reorder anything and there's zero per-frame kernel traffic. As a result `value`/`playing` become one-way Python→JS controls (setting them still drives the widget, but the widget no longer reports the live playhead back), so the demo's live-readout cell was removed. Also bumps the version to 0.5.18 with a changelog entry and updates the demo's `wigglystuff` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)