### PR TITLE
ManimWeb: surface scene runtime errors via the error traitlet (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `ManimWeb`: runtime errors thrown inside the scene now reach the `error` traitlet and render in the cell. The recommended `player.sequence(async (scene) => {...})` entry point returns immediately and runs its callback detached from the promise the widget awaits, so a throw inside the scene (e.g. misusing a manim-web constructor) was an unhandled promise rejection visible only in the browser console — the widget rendered blank and `widget.error` stayed `""`. A window `unhandledrejection` listener now routes those into the existing error surface, so scene bugs are visible in the notebook and readable from Python. Fixes #291.
+
 ## [0.5.18] - 2026-07-15
 
 ### Fixed

--- a/wigglystuff/static/manim-web.js
+++ b/wigglystuff/static/manim-web.js
@@ -44,6 +44,8 @@ function render({ model, el }) {
 
   // Bumped on every (re)run so a stale async run can't clobber a newer one.
   let runToken = 0;
+  // Flipped in the cleanup so a late rejection can't touch a removed widget.
+  let disposed = false;
 
   function applySize() {
     container.style.width = model.get("width") + "px";
@@ -100,6 +102,23 @@ function render({ model, el }) {
     }
   }
 
+  // The recommended entry point, `player.sequence(async (scene) => {...})`,
+  // returns immediately and runs its callback detached from the promise `run`
+  // awaits — so a throw inside the scene is an *unhandled* rejection the
+  // try/catch in `run` never sees. Catch those here so scene bugs still reach
+  // the `error` traitlet (and the cell) instead of only the browser console.
+  //
+  // Caveat: `unhandledrejection` is a page-global event, so with multiple live
+  // ManimWeb widgets a rejection from one may be reported by all of them. The
+  // target use (one scene under iteration) is single-widget, and surfacing a
+  // stray error beats the current silent failure — so we keep it simple.
+  function onRejection(event) {
+    if (disposed) return;
+    const reason = event.reason;
+    showError((reason && reason.stack) || String(reason));
+  }
+  window.addEventListener("unhandledrejection", onRejection);
+
   applySize();
   run();
 
@@ -117,6 +136,8 @@ function render({ model, el }) {
   return () => {
     // Invalidate any in-flight run so it stops touching the removed DOM.
     runToken++;
+    disposed = true;
+    window.removeEventListener("unhandledrejection", onRejection);
   };
 }
 


### PR DESCRIPTION
Fixes #291. A `ManimWeb` scene's runtime errors were invisible: the recommended `player.sequence(async (scene) => {...})` entry point runs its callback detached from the promise `render()` awaits, so a throw inside the scene became an unhandled promise rejection seen only in the browser console — the widget rendered blank and `widget.error` stayed `""`. This adds a per-instance window `unhandledrejection` listener that routes those errors through the existing `showError()` surface, so scene bugs now render in the cell and are readable from Python. The listener is guarded by a `disposed` flag and removed on teardown, and the CHANGELOG gets an `## [Unreleased]` entry. Known caveat (documented in a code comment): `unhandledrejection` is page-global, so with multiple live ManimWeb widgets a rejection from one may be reported by all — an accepted trade-off for the single-widget iteration use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)