### PR TITLE
WidgetDAG: raise a clear error when displayed outside marimo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- `WidgetDAG` now raises a clear `RuntimeError` when displayed outside a running marimo notebook (in plain Jupyter/IPython or without a live kernel) instead of showing a silent plain-text repr. It renders by reaching into marimo's DOM, so it is marimo-only by design.
+
 ## [0.5.20] - 2026-07-17
 
 ### Added

--- a/tests/test_widget_dag.py
+++ b/tests/test_widget_dag.py
@@ -1,3 +1,5 @@
+import pytest
+
 from wigglystuff import WidgetDAG
 from wigglystuff.widget_dag import _reduce_edges, layered_layout
 
@@ -58,3 +60,12 @@ def test_widget_dag_stores_nodes_edges_and_layout():
     assert widget.nodes == {"image": "<img>", "conv": "<img>"}
     assert widget.edges == [["image", "conv"]]
     assert widget.layout is layered_layout
+
+
+def test_widget_dag_display_raises_outside_marimo():
+    # Tests run outside a marimo kernel, so both display hooks should refuse.
+    widget = WidgetDAG(nodes={"a": "<img>"}, edges=[])
+    with pytest.raises(RuntimeError, match="marimo-only"):
+        widget._display_()
+    with pytest.raises(RuntimeError, match="marimo-only"):
+        widget._repr_mimebundle_()

--- a/wigglystuff/widget_dag.py
+++ b/wigglystuff/widget_dag.py
@@ -20,6 +20,27 @@ class _Arrows(anywidget.AnyWidget):
     edges = traitlets.List().tag(sync=True)
 
 
+def _require_marimo_notebook():
+    """Raise unless we are displaying inside a running marimo notebook.
+
+    ``WidgetDAG`` renders by reaching into marimo's rendered DOM, so it is a
+    no-op anywhere else. Mirrors the ``mo.running_in_notebook()`` check in
+    ``wigglystuff/_marimo_notice.py``.
+    """
+    try:
+        import marimo as mo
+
+        if mo.running_in_notebook():
+            return
+    except ImportError:
+        pass
+    raise RuntimeError(
+        "WidgetDAG is a marimo-only display helper: it renders by reaching "
+        "into marimo's rendered DOM and does not work outside a running "
+        "marimo notebook."
+    )
+
+
 def layered_layout(nodes, edges):
     """Assign each node a column (0 = leftmost).
 
@@ -170,7 +191,13 @@ class WidgetDAG:
         edges = _reduce_edges(order, name_to_cell, ancestors)
         return cls(nodes, edges, layout=layout)
 
+    def _repr_mimebundle_(self, **kwargs):
+        # marimo prefers ``_display_``, so this only fires in Jupyter/IPython,
+        # where it turns a silent plain-text repr into a clear error.
+        _require_marimo_notebook()
+
     def _display_(self):
+        _require_marimo_notebook()
         import marimo as mo
 
         depth = self.layout(self.nodes, self.edges)


### PR DESCRIPTION
`WidgetDAG` renders by reaching into marimo's rendered DOM, so it is a marimo-only display helper — but nothing enforced that: in plain Jupyter/IPython it showed a silent `<WidgetDAG object at 0x…>` repr, and `_display_` without a live kernel would crash opaquely. This adds a `_require_marimo_notebook()` guard (using the canonical `mo.running_in_notebook()` check) to both `_display_` and a new `_repr_mimebundle_` hook, so any non-marimo environment now gets a clear `RuntimeError`. A unit test covers both hooks and the CHANGELOG has an `[Unreleased]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)