### PR TITLE
Fix gallery buttons overflowing on mobile docs

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -338,6 +338,7 @@
    —————————————————————————————————————————— */
 @media (max-width: 600px) {
   .gallery-links {
+    flex-wrap: wrap;
     gap: 0.375rem;
     padding: 0.5rem;
   }
@@ -345,5 +346,10 @@
   .gallery-links a {
     font-size: 0.65rem;
     padding: 0.25rem 0.5rem;
+  }
+
+  /* Drop the raw-markdown ("MD") link on mobile to keep the row on one line */
+  .gallery-links a[href$=".md"] {
+    display: none;
   }
 }


### PR DESCRIPTION
On narrow (≤600px) screens the widget gallery drops to two columns, but the button row was locked to a single non-wrapping line, so the three buttons (molab / API / MD) spilled past the card edge and got clipped by the card's `overflow: hidden`. This hides the least-important MD (raw-markdown) link on mobile and lets the row wrap as a safety net. Desktop and tablet are unchanged — all three buttons still render on one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)