### PR TITLE
TangleLatex: remove faux underline on draggable markers

### DIFF
--- a/wigglystuff/static/latex-tangle.css
+++ b/wigglystuff/static/latex-tangle.css
@@ -91,10 +91,6 @@
   z-index: 1;
 }
 
-.latex-tangle__formula [data-tangle-param] > * {
-  box-shadow: inset 0 -0.065em 0 color-mix(in srgb, currentColor, transparent 32%);
-}
-
 .latex-tangle__formula .katex-html * {
   pointer-events: none;
 }


### PR DESCRIPTION
The draggable `\tangle{...}` markers in `TangleLatex` had a faux underline (an inset bottom box-shadow on `[data-tangle-param] > *`) that only rendered when KaTeX wrapped a marker's content in a child element — e.g. the base of a superscript like `\sigma^2` — so it appeared inconsistently across markers. This removes that rule so every draggable marker looks the same, while the color and hover/focus/active highlight are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)