### PR TITLE
Add conversion of Excalidraw state to Mermaid code.

### DIFF
--- a/demos/excalidraw.py
+++ b/demos/excalidraw.py
@@ -136,5 +136,12 @@ def _(Excalidraw, mo):
     return
 
 
+@app.cell
+def _(draw, mo):
+    # The current scene can be converted to Mermaid code
+    mo.mermaid(draw.to_mermaid(direction = "LR"))
+    return
+
+
 if __name__ == "__main__":
     app.run()

--- a/wigglystuff/excalidraw.py
+++ b/wigglystuff/excalidraw.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 import anywidget
 import traitlets
+import re
 
 DEFAULT_HEIGHT = 600
 
@@ -98,6 +99,160 @@ class Excalidraw(anywidget.AnyWidget):
     def to_json(self) -> str:
         """Return the current scene serialized as a JSON string."""
         return json.dumps(self.scene)
+
+    def to_mermaid(self, direction: str = "TD") -> str:
+        """
+        Convert an Excalidraw scene dict (as returned by wigglystuff's
+        `draw.scene` in marimo) into Mermaid flowchart syntax.
+    
+        Strategy
+        --------
+        - Shape elements (rectangle / diamond / ellipse) become nodes.
+        - Text elements get resolved to their parent shape via the shape's
+        `boundElements` (falling back to the text's own `containerId`),
+        so a shape's label always comes from its bound text, not from
+        guessing based on position.
+        - Text elements with no `containerId` are treated as free-standing
+        label nodes.
+        - Arrow/line elements become edges, using `startBinding` /
+        `endBinding` to find which nodes they connect. If the arrow
+        itself has bound text (a label), that becomes the edge label.
+        - Deleted elements (`isDeleted: True`) are ignored.
+        - Color is carried over from each element's own `strokeColor` /
+        `backgroundColor` / `strokeWidth` attributes (not inherited or
+        guessed from bound elements) and emitted as `style` directives
+        for nodes and `linkStyle` directives for edges.
+        """
+        state = self.scene
+        elements = [e for e in state.get("elements", []) if not e.get("isDeleted")]
+        by_id = {e["id"]: e for e in elements}
+
+        SHAPE_TYPES = {"rectangle", "diamond", "ellipse"}
+
+        def safe_id(eid: str) -> str:
+            # Mermaid node ids must be alnum/underscore-ish; prefix to
+            # guarantee it doesn't start with a digit.
+            return "n" + re.sub(r"[^a-zA-Z0-9_]", "_", eid)
+
+        def clean_label(text: str) -> str:
+            text = (text or "").strip()
+            text = text.replace('"', "'").replace("\n", "<br/>")
+            return text
+
+        def bound_text_for(element: dict) -> str:
+            """Find the text bound to `element` via its boundElements list."""
+            for bound in element.get("boundElements") or []:
+                if bound.get("type") == "text":
+                    text_el = by_id.get(bound.get("id"))
+                    if text_el is not None:
+                        return text_el.get("text", "")
+            return ""
+
+        def color_attrs(element: dict, force_bare: bool = False) -> tuple[str, str, int]:
+            """
+            Pull an element's own rendering attributes straight off the dict:
+            (strokeColor, backgroundColor, strokeWidth). Excalidraw uses the
+            string "transparent" for "no fill", which we normalize to
+            Mermaid's `fill:none`.
+
+            `force_bare=True` is for plain text elements: excalidraw text
+            has no real border/background of its own, so we render it with
+            no outline and no fill regardless of the raw attribute values.
+            """
+            if force_bare:
+                return "none", "none", 0
+            stroke = element.get("strokeColor") or "#1e1e1e"
+            bg = element.get("backgroundColor") or "transparent"
+            bg = "none" if bg == "transparent" else bg
+            width = element.get("strokeWidth") or 1
+            return stroke, bg, width
+
+        def node_shape_wrap(label: str, shape_type: str) -> str:
+            label = clean_label(label) or " "
+            if shape_type == "diamond":
+                return f'{{"{label}"}}'
+            if shape_type == "ellipse":
+                return f'(("{label}"))'
+            if shape_type == "text":
+                # Plain text has no real "shape" in excalidraw; still needs a
+                # node wrapper for Mermaid syntax, but we suppress its
+                # border/fill below via color_attrs override.
+                return f'["{label}"]'
+            # rectangle
+            return f'["{label}"]'
+
+        #    Collect shape nodes, using bound text (via boundElements) for labels.
+        #    Color/stroke-width always come from the *shape* element itself,
+        #    never from its bound text.
+        nodes: dict[str, tuple[str, str, str, str, int]] = {}
+        text_ids_used_as_labels: set[str] = set()
+
+        for e in elements:
+            if e.get("type") in SHAPE_TYPES:
+                label = bound_text_for(e)
+                stroke, bg, width = color_attrs(e)
+                nodes[e["id"]] = (label, e["type"], stroke, bg, width)
+                for bound in e.get("boundElements") or []:
+                    if bound.get("type") == "text":
+                        text_ids_used_as_labels.add(bound["id"])
+
+        #    Free-standing text elements (no container, not already used as a
+        #    label for a shape or arrow) become their own label-only nodes,
+        #    colored using the text element's own strokeColor.
+        for e in elements:
+            if e.get("type") == "text" and e["id"] not in text_ids_used_as_labels:
+                if not e.get("containerId"):
+                    stroke, bg, width = color_attrs(e, force_bare=True)
+                    nodes[e["id"]] = (e.get("text", ""), "text", stroke, bg, width)
+
+        #    Arrows/lines become edges between bound elements, colored using
+        #    the arrow/line element's own strokeColor + strokeWidth.
+        edges = []
+        for e in elements:
+            if e.get("type") in ("arrow", "line"):
+                start_binding = e.get("startBinding") or {}
+                end_binding = e.get("endBinding") or {}
+                start_id = start_binding.get("elementId")
+                end_id = end_binding.get("elementId")
+                if start_id and end_id:
+                    label = bound_text_for(e)
+                    stroke, _bg, width = color_attrs(e)
+                    for bound in e.get("boundElements") or []:
+                        if bound.get("type") == "text":
+                            text_ids_used_as_labels.add(bound["id"])
+                    edges.append((start_id, end_id, label, stroke, width))
+
+        #  Emit Mermaid.
+        lines = [f"flowchart {direction}"]
+
+        for node_id, (label, shape_type, _stroke, _bg, _width) in nodes.items():
+            lines.append(f"    {safe_id(node_id)}{node_shape_wrap(label, shape_type)}")
+
+        edge_lines = []
+        edge_styles = []  # (linkIndex, stroke, width) - index must match edge_lines order
+        for start_id, end_id, label, stroke, width in edges:
+            if start_id not in nodes or end_id not in nodes:
+                continue  # dangling arrow, nothing to connect
+            if label:
+                edge_lines.append(f"    {safe_id(start_id)} -->|{clean_label(label)}| {safe_id(end_id)}")
+            else:
+                edge_lines.append(f"    {safe_id(start_id)} --> {safe_id(end_id)}")
+            edge_styles.append((len(edge_lines) - 1, stroke, width))
+
+        lines.extend(edge_lines)
+
+        # Node styling: fill = backgroundColor, stroke = strokeColor.
+        for node_id, (_label, _shape_type, stroke, bg, width) in nodes.items():
+            lines.append(
+                f"    style {safe_id(node_id)} fill:{bg},stroke:{stroke},stroke-width:{width}px"
+            )
+
+        # Edge styling: Mermaid's linkStyle addresses edges by their 0-based
+        # position among --> statements, so we track that position above.
+        for idx, stroke, width in edge_styles:
+            lines.append(f"    linkStyle {idx} stroke:{stroke},stroke-width:{width}px")
+
+        return "\n".join(lines)
 
     def save(self, path: Optional[Union[str, Path]] = None) -> Path:
         """Write the current scene to a ``.excalidraw`` JSON file and return where.

--- a/wigglystuff/excalidraw.py
+++ b/wigglystuff/excalidraw.py
@@ -101,158 +101,8 @@ class Excalidraw(anywidget.AnyWidget):
         return json.dumps(self.scene)
 
     def to_mermaid(self, direction: str = "TD") -> str:
-        """
-        Convert an Excalidraw scene dict (as returned by wigglystuff's
-        `draw.scene` in marimo) into Mermaid flowchart syntax.
-    
-        Strategy
-        --------
-        - Shape elements (rectangle / diamond / ellipse) become nodes.
-        - Text elements get resolved to their parent shape via the shape's
-        `boundElements` (falling back to the text's own `containerId`),
-        so a shape's label always comes from its bound text, not from
-        guessing based on position.
-        - Text elements with no `containerId` are treated as free-standing
-        label nodes.
-        - Arrow/line elements become edges, using `startBinding` /
-        `endBinding` to find which nodes they connect. If the arrow
-        itself has bound text (a label), that becomes the edge label.
-        - Deleted elements (`isDeleted: True`) are ignored.
-        - Color is carried over from each element's own `strokeColor` /
-        `backgroundColor` / `strokeWidth` attributes (not inherited or
-        guessed from bound elements) and emitted as `style` directives
-        for nodes and `linkStyle` directives for edges.
-        """
-        state = self.scene
-        elements = [e for e in state.get("elements", []) if not e.get("isDeleted")]
-        by_id = {e["id"]: e for e in elements}
-
-        SHAPE_TYPES = {"rectangle", "diamond", "ellipse"}
-
-        def safe_id(eid: str) -> str:
-            # Mermaid node ids must be alnum/underscore-ish; prefix to
-            # guarantee it doesn't start with a digit.
-            return "n" + re.sub(r"[^a-zA-Z0-9_]", "_", eid)
-
-        def clean_label(text: str) -> str:
-            text = (text or "").strip()
-            text = text.replace('"', "'").replace("\n", "<br/>")
-            return text
-
-        def bound_text_for(element: dict) -> str:
-            """Find the text bound to `element` via its boundElements list."""
-            for bound in element.get("boundElements") or []:
-                if bound.get("type") == "text":
-                    text_el = by_id.get(bound.get("id"))
-                    if text_el is not None:
-                        return text_el.get("text", "")
-            return ""
-
-        def color_attrs(element: dict, force_bare: bool = False) -> tuple[str, str, int]:
-            """
-            Pull an element's own rendering attributes straight off the dict:
-            (strokeColor, backgroundColor, strokeWidth). Excalidraw uses the
-            string "transparent" for "no fill", which we normalize to
-            Mermaid's `fill:none`.
-
-            `force_bare=True` is for plain text elements: excalidraw text
-            has no real border/background of its own, so we render it with
-            no outline and no fill regardless of the raw attribute values.
-            """
-            if force_bare:
-                return "none", "none", 0
-            stroke = element.get("strokeColor") or "#1e1e1e"
-            bg = element.get("backgroundColor") or "transparent"
-            bg = "none" if bg == "transparent" else bg
-            width = element.get("strokeWidth") or 1
-            return stroke, bg, width
-
-        def node_shape_wrap(label: str, shape_type: str) -> str:
-            label = clean_label(label) or " "
-            if shape_type == "diamond":
-                return f'{{"{label}"}}'
-            if shape_type == "ellipse":
-                return f'(("{label}"))'
-            if shape_type == "text":
-                # Plain text has no real "shape" in excalidraw; still needs a
-                # node wrapper for Mermaid syntax, but we suppress its
-                # border/fill below via color_attrs override.
-                return f'["{label}"]'
-            # rectangle
-            return f'["{label}"]'
-
-        #    Collect shape nodes, using bound text (via boundElements) for labels.
-        #    Color/stroke-width always come from the *shape* element itself,
-        #    never from its bound text.
-        nodes: dict[str, tuple[str, str, str, str, int]] = {}
-        text_ids_used_as_labels: set[str] = set()
-
-        for e in elements:
-            if e.get("type") in SHAPE_TYPES:
-                label = bound_text_for(e)
-                stroke, bg, width = color_attrs(e)
-                nodes[e["id"]] = (label, e["type"], stroke, bg, width)
-                for bound in e.get("boundElements") or []:
-                    if bound.get("type") == "text":
-                        text_ids_used_as_labels.add(bound["id"])
-
-        #    Free-standing text elements (no container, not already used as a
-        #    label for a shape or arrow) become their own label-only nodes,
-        #    colored using the text element's own strokeColor.
-        for e in elements:
-            if e.get("type") == "text" and e["id"] not in text_ids_used_as_labels:
-                if not e.get("containerId"):
-                    stroke, bg, width = color_attrs(e, force_bare=True)
-                    nodes[e["id"]] = (e.get("text", ""), "text", stroke, bg, width)
-
-        #    Arrows/lines become edges between bound elements, colored using
-        #    the arrow/line element's own strokeColor + strokeWidth.
-        edges = []
-        for e in elements:
-            if e.get("type") in ("arrow", "line"):
-                start_binding = e.get("startBinding") or {}
-                end_binding = e.get("endBinding") or {}
-                start_id = start_binding.get("elementId")
-                end_id = end_binding.get("elementId")
-                if start_id and end_id:
-                    label = bound_text_for(e)
-                    stroke, _bg, width = color_attrs(e)
-                    for bound in e.get("boundElements") or []:
-                        if bound.get("type") == "text":
-                            text_ids_used_as_labels.add(bound["id"])
-                    edges.append((start_id, end_id, label, stroke, width))
-
-        #  Emit Mermaid.
-        lines = [f"flowchart {direction}"]
-
-        for node_id, (label, shape_type, _stroke, _bg, _width) in nodes.items():
-            lines.append(f"    {safe_id(node_id)}{node_shape_wrap(label, shape_type)}")
-
-        edge_lines = []
-        edge_styles = []  # (linkIndex, stroke, width) - index must match edge_lines order
-        for start_id, end_id, label, stroke, width in edges:
-            if start_id not in nodes or end_id not in nodes:
-                continue  # dangling arrow, nothing to connect
-            if label:
-                edge_lines.append(f"    {safe_id(start_id)} -->|{clean_label(label)}| {safe_id(end_id)}")
-            else:
-                edge_lines.append(f"    {safe_id(start_id)} --> {safe_id(end_id)}")
-            edge_styles.append((len(edge_lines) - 1, stroke, width))
-
-        lines.extend(edge_lines)
-
-        # Node styling: fill = backgroundColor, stroke = strokeColor.
-        for node_id, (_label, _shape_type, stroke, bg, width) in nodes.items():
-            lines.append(
-                f"    style {safe_id(node_id)} fill:{bg},stroke:{stroke},stroke-width:{width}px"
-            )
-
-        # Edge styling: Mermaid's linkStyle addresses edges by their 0-based
-        # position among --> statements, so we track that position above.
-        for idx, stroke, width in edge_styles:
-            lines.append(f"    linkStyle {idx} stroke:{stroke},stroke-width:{width}px")
-
-        return "\n".join(lines)
+        """Return the current scene as Mermaid code"""
+        return excalidraw_to_mermaid(self.scene, direction  = direction)
 
     def save(self, path: Optional[Union[str, Path]] = None) -> Path:
         """Write the current scene to a ``.excalidraw`` JSON file and return where.
@@ -288,3 +138,197 @@ class Excalidraw(anywidget.AnyWidget):
         widget = cls(scene=scene, **kwargs)
         widget.source_path = Path(path)
         return widget
+
+
+def excalidraw_to_mermaid(state: dict, direction: str = "TD") -> str:
+    """
+    Convert an Excalidraw scene dict (as returned by wigglystuff's
+    `draw.scene` in marimo) into Mermaid flowchart syntax.
+ 
+    Strategy
+    --------
+    - Shape elements (rectangle / diamond / ellipse) become nodes.
+    - Text elements get resolved to their parent shape via the shape's
+      `boundElements` (falling back to the text's own `containerId`),
+      so a shape's label always comes from its bound text, not from
+      guessing based on position.
+    - Text elements with no `containerId` are treated as free-standing
+      label nodes.
+    - Arrow/line elements become edges, using `startBinding` /
+      `endBinding` to find which nodes they connect. If the arrow
+      itself has bound text (a label), that becomes the edge label.
+    - Deleted elements (`isDeleted: True`) are ignored.
+    - Color is carried over from each element's own `strokeColor` /
+      `backgroundColor` / `strokeWidth` attributes (not inherited or
+      guessed from bound elements) and emitted as `style` directives
+      for nodes and `linkStyle` directives for edges.
+ 
+    Parameters
+    ----------
+    state : dict
+        The excalidraw scene dict, expected to have an "elements" key.
+    direction : str
+        Mermaid flowchart direction, e.g. "TD", "LR", "BT", "RL".
+ 
+    Returns
+    -------
+    str
+        Mermaid flowchart source code.
+    """
+    elements = [e for e in state.get("elements", []) if not e.get("isDeleted")]
+    by_id = {e["id"]: e for e in elements}
+ 
+    SHAPE_TYPES = {"rectangle", "diamond", "ellipse"}
+ 
+    def safe_id(eid: str) -> str:
+        # Mermaid node ids must be alnum/underscore-ish; prefix to
+        # guarantee it doesn't start with a digit.
+        return "n" + re.sub(r"[^a-zA-Z0-9_]", "_", eid)
+ 
+    def clean_label(text: str) -> str:
+        text = (text or "").strip()
+        text = text.replace('"', "'").replace("\n", "<br/>")
+        return text
+ 
+    def bound_text_for(element: dict) -> str:
+        """Find the text bound to `element` via its boundElements list."""
+        for bound in element.get("boundElements") or []:
+            if bound.get("type") == "text":
+                text_el = by_id.get(bound.get("id"))
+                if text_el is not None:
+                    return text_el.get("text", "")
+        return ""
+ 
+    def color_attrs(element: dict, force_bare: bool = False) -> tuple[str, str, int]:
+        """
+        Pull an element's own rendering attributes straight off the dict:
+        (strokeColor, backgroundColor, strokeWidth). Excalidraw uses the
+        string "transparent" for "no fill", which we normalize to
+        Mermaid's `fill:none`.
+ 
+        `force_bare=True` is for plain text elements: excalidraw text
+        has no real border/background of its own, so we render it with
+        no outline and no fill regardless of the raw attribute values.
+        """
+        if force_bare:
+            return "none", "none", 0
+        stroke = element.get("strokeColor") or "#1e1e1e"
+        bg = element.get("backgroundColor") or "transparent"
+        bg = "none" if bg == "transparent" else bg
+        width = element.get("strokeWidth") or 1
+        return stroke, bg, width
+ 
+    def node_shape_wrap(label: str, shape_type: str) -> str:
+        label = clean_label(label) or " "
+        if shape_type == "diamond":
+            return f'{{"{label}"}}'
+        if shape_type == "ellipse":
+            # Mermaid's single-paren `(text)` is a rounded rectangle, not
+            # an ellipse/circle. Double parens give an actual circle.
+            return f'(("{label}"))'
+        if shape_type == "text":
+            # Plain text has no real "shape" in excalidraw; still needs a
+            # node wrapper for Mermaid syntax, but we suppress its
+            # border/fill below via color_attrs override.
+            return f'["{label}"]'
+        # rectangle
+        return f'["{label}"]'
+ 
+    # 1. Collect shape nodes, using bound text (via boundElements) for labels.
+    #    Color/stroke-width always come from the *shape* element itself,
+    #    never from its bound text.
+    nodes: dict[str, tuple[str, str, str, str, int]] = {}
+    text_ids_used_as_labels: set[str] = set()
+ 
+    for e in elements:
+        if e.get("type") in SHAPE_TYPES:
+            label = bound_text_for(e)
+            stroke, bg, width = color_attrs(e)
+            nodes[e["id"]] = (label, e["type"], stroke, bg, width)
+            for bound in e.get("boundElements") or []:
+                if bound.get("type") == "text":
+                    text_ids_used_as_labels.add(bound["id"])
+ 
+    # 2. Free-standing text elements (no container, not already used as a
+    #    label for a shape or arrow) become their own label-only nodes,
+    #    colored using the text element's own strokeColor.
+    for e in elements:
+        if e.get("type") == "text" and e["id"] not in text_ids_used_as_labels:
+            if not e.get("containerId"):
+                stroke, bg, width = color_attrs(e, force_bare=True)
+                nodes[e["id"]] = (e.get("text", ""), "text", stroke, bg, width)
+ 
+    # 3. Arrows/lines become edges between bound elements, colored using
+    #    the arrow/line element's own strokeColor + strokeWidth. Arrowhead
+    #    presence on each end determines direction: excalidraw defaults to
+    #    startArrowhead=None, endArrowhead="arrow" for a normal A->B arrow.
+    #    strokeStyle "dashed"/"dotted" becomes a dashed Mermaid connector,
+    #    since it's usually meaningful (e.g. "optional"/"implied") rather
+    #    than purely decorative.
+    def has_head(arrowhead) -> bool:
+        return arrowhead is not None and arrowhead != "none"
+ 
+    edges = []
+    for e in elements:
+        if e.get("type") in ("arrow", "line"):
+            start_binding = e.get("startBinding") or {}
+            end_binding = e.get("endBinding") or {}
+            start_id = start_binding.get("elementId")
+            end_id = end_binding.get("elementId")
+            if start_id and end_id:
+                label = bound_text_for(e)
+                stroke, _bg, width = color_attrs(e)
+                for bound in e.get("boundElements") or []:
+                    if bound.get("type") == "text":
+                        text_ids_used_as_labels.add(bound["id"])
+ 
+                start_head = has_head(e.get("startArrowhead"))
+                end_head = has_head(e.get("endArrowhead"))
+                is_dashed = e.get("strokeStyle") in ("dashed", "dotted")
+ 
+                if start_head and not end_head:
+                    # Arrowhead is on the "start" end only: flip so Mermaid
+                    # draws the head where excalidraw drew it.
+                    start_id, end_id = end_id, start_id
+                    start_head, end_head = end_head, start_head
+ 
+                if start_head and end_head:
+                    arrow_op = "<-.->" if is_dashed else "<-->"
+                elif end_head:
+                    arrow_op = "-.->" if is_dashed else "-->"
+                else:
+                    arrow_op = "-.-" if is_dashed else "---"
+ 
+                edges.append((start_id, end_id, label, stroke, width, arrow_op))
+ 
+    # 4. Emit Mermaid.
+    lines = [f"flowchart {direction}"]
+ 
+    for node_id, (label, shape_type, _stroke, _bg, _width) in nodes.items():
+        lines.append(f"    {safe_id(node_id)}{node_shape_wrap(label, shape_type)}")
+ 
+    edge_lines = []
+    edge_styles = []  # (linkIndex, stroke, width) - index must match edge_lines order
+    for start_id, end_id, label, stroke, width, arrow_op in edges:
+        if start_id not in nodes or end_id not in nodes:
+            continue  # dangling arrow, nothing to connect
+        if label:
+            edge_lines.append(f"    {safe_id(start_id)} {arrow_op}|{clean_label(label)}| {safe_id(end_id)}")
+        else:
+            edge_lines.append(f"    {safe_id(start_id)} {arrow_op} {safe_id(end_id)}")
+        edge_styles.append((len(edge_lines) - 1, stroke, width))
+ 
+    lines.extend(edge_lines)
+ 
+    # Node styling: fill = backgroundColor, stroke = strokeColor.
+    for node_id, (_label, _shape_type, stroke, bg, width) in nodes.items():
+        lines.append(
+            f"    style {safe_id(node_id)} fill:{bg},stroke:{stroke},stroke-width:{width}px"
+        )
+ 
+    # Edge styling: Mermaid's linkStyle addresses edges by their 0-based
+    # position among --> statements, so we track that position above.
+    for idx, stroke, width in edge_styles:
+        lines.append(f"    linkStyle {idx} stroke:{stroke},stroke-width:{width}px")
+ 
+    return "\n".join(lines)


### PR DESCRIPTION
Closes issue #306. Excalidraw is likely going to be adding an Export to Mermaid feature soon (https://github.com/excalidraw/excalidraw/pull/11330) but I thought it would be nice to add a direct to_mermaid in the Excalidraw widget itself as I think this will work better within marimo notebooks than relying on the future Excalidraw export functionality. 

I'm keeping this as draft for now to see if the Excalidraw export to Mermaid functionality gets merged soon, would be better to have consistent conversion functionality, but only if it will integrate well with Marimo. 