### PR TITLE
demos: trim redundant cells from widget_dag demo

### DIFF
--- a/demos/widget_dag.py
+++ b/demos/widget_dag.py
@@ -53,20 +53,6 @@ def _(mo):
 
 
 @app.cell
-def _(angle, conv, conv2, kernel, kernel2, paint):
-    [conv, angle, paint, kernel, kernel2, conv2]
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    Above is "meh", we can do better below.
-    """)
-    return
-
-
-@app.cell
 def _(WidgetDAG, angle, conv, conv2, kernel, kernel2, paint):
     WidgetDAG.from_widgets([paint, angle, kernel, conv, kernel2, conv2])
     return


### PR DESCRIPTION
Removes two now-redundant cells from `demos/widget_dag.py`: an intermediate plain-list display of the widgets and the "Above is 'meh', we can do better below." markdown cell that introduced it. The demo now goes straight to the `WidgetDAG.from_widgets(...)` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)