### PR TITLE
ci: stop running browser E2E tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,34 +22,7 @@ jobs:
           python -m pip install --upgrade uv
           uv venv
           uv pip install -e ".[test]"
+          # tests/test_e2e is browser-driven and too flaky to gate PRs on; it is
+          # kept for local use only (make test-browser) and Playwright is not
+          # installed here, so collection would fail without this ignore.
           uv run pytest --ignore=tests/test_e2e
-
-  e2e-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade uv
-          uv venv
-          uv pip install -e ".[test-browser]"
-      - name: Get Playwright version
-        id: pw-version
-        run: echo "version=$(uv run python -c 'from importlib.metadata import version; print(version("playwright"))')" >> "$GITHUB_OUTPUT"
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.pw-version.outputs.version }}-chromium
-      - name: Install Playwright browsers
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: uv run playwright install chromium --with-deps
-      - name: Install Playwright system deps
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: uv run playwright install-deps chromium
-      - name: Pytest (e2e tests)
-        run: uv run pytest tests/test_e2e -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,6 @@ syncs back to Python.
   starting branch-finishing workflows. The user may want another design pass.
 - During visual iteration, do not repeatedly run automated checks after CSS,
   SVG, layout, or styling tweaks. Make the change and return it for inspection.
-- Browser E2E tests are exceptional, not the default for a widget. Add or run
-  them only when the user requests them or after the user approves a specific
-  browser behavior that cannot be covered meaningfully in Python.
 - After visual approval, run the smallest focused checks once. Run the full
   repository suite only when preparing to ship/merge or when shared
   infrastructure changed.
@@ -159,10 +156,3 @@ syncs back to Python.
 - When planning a new widget, always present the proposed Python API
   (constructor, traitlets, helper methods) during plan review so the user
   can sign off on the interface before implementation.
-- When an explicitly approved E2E test needs a fixture, keep it in
-  `tests/fixtures/*.py` or `demos/*.py` inside the project tree. The repo's `pyproject.toml`
-  sets `[tool.marimo.runtime] auto_instantiate = true` so cells run on
-  notebook open — without that, `marimo edit` shows the editor but never
-  produces widget output and selectors will time out. If a test needs an
-  isolated copy, put the copy somewhere a `pyproject.toml` walk reaches,
-  not under `tmp_path`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: js docs test test-links docs-serve marimo-notebook marimo-sessions
+.PHONY: js docs test test-browser test-all test-links docs-serve marimo-notebook marimo-sessions
 
 install:
 	# install the build tool for JS written in Golang
@@ -11,7 +11,7 @@ install:
 
 test:
 	uv pip install -e '.[test]'
-	uv run pytest --ignore=tests/test_browser
+	uv run pytest --ignore=tests/test_e2e
 
 test-links: docs
 	uv pip install -e '.[test]'
@@ -20,10 +20,11 @@ test-links: docs
 		--ignore=site/overrides \
 		--check-links-ignore '^https?://'
 
+# Browser tests are local-only; they are not run in CI.
 test-browser:
 	uv pip install -e '.[test-browser]'
 	uv run playwright install chromium
-	uv run pytest tests/test_browser -v
+	uv run pytest tests/test_e2e -v
 
 test-all:
 	uv pip install -e '.[test-browser]'


### PR DESCRIPTION
The Playwright suite in `tests/test_e2e` boots a real marimo server and drives a browser, making it too flaky to gate PRs on — so this drops the `e2e-tests` job and CI now runs unit tests only. The tests, fixtures, `conftest.py` and the `test-browser` extra are all kept, so the suite stays runnable locally via `make test-browser`.

This also fixes a latent Makefile bug: both E2E targets pointed at `tests/test_browser`, a directory that does not exist (the real one is `tests/test_e2e`), so `make test` was never actually skipping the browser tests and `make test-browser` silently collected zero tests. Finally, the two E2E guidance passages in `AGENTS.md` are removed, and the `--ignore=tests/test_e2e` flag on the unit job gains a comment noting it is now load-bearing — with no job installing Playwright, collection would hard-fail without it.

Verified: workflow parses with `jobs` = `['tests']`, and `pytest --ignore=tests/test_e2e` passes 305 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)