### PR TITLE
tests: give HeatmapSelect its own import test

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -43,6 +43,9 @@ def test_import_graph_widget():
 
 def test_import_grid_draw():
     from wigglystuff.grid_draw import GridDraw
+
+
+def test_import_heatmap_select():
     from wigglystuff.heatmap_select import HeatmapSelect
 
 


### PR DESCRIPTION
The 0.5.23 release added the `HeatmapSelect` import to the body of `test_import_grid_draw` rather than its own test function, so the two modules shared a single case. This splits them, restoring one-test-per-module.

Found while merging main into #314; the merge output was byte-identical to main, confirming it came in with the release rather than from a bad conflict resolution.

Worth noting for context: `tests/test_imports.py` covers 24 of 55 widget modules, so it is a partial list rather than an exhaustive contract — this fixes the malformed case without attempting to close that wider gap. 324 tests pass (`uv run pytest --ignore=tests/test_e2e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)