### PR TITLE
docs: add four demo videos in a responsive grid

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -347,9 +347,15 @@
    —————————————————————————————————————————— */
 .youtube-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(2, 1fr);
   gap: 1.25rem;
   margin: 1rem 0 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .youtube-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .youtube-embed {

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -22,4 +22,20 @@
 <iframe src="https://www.youtube.com/embed/dVrkzc_arE8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
+<div class="youtube-embed">
+<iframe src="https://www.youtube.com/embed/q8UBH54B2Rg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+<div class="youtube-embed">
+<iframe src="https://www.youtube.com/embed/VD5bAOvDxFY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+<div class="youtube-embed">
+<iframe src="https://www.youtube.com/embed/BrQLCqofc30" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+<div class="youtube-embed">
+<iframe src="https://www.youtube.com/embed/qVSeOr3AIbc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
 </div>


### PR DESCRIPTION
Adds four more YouTube demos to the Demos page (`docs/demos.md`) — three CalmCode videos and marimo's "A New Era of Python GUIs" — bringing the total to nine.

Switches `.youtube-grid` from a single column to a two-column layout that collapses to one column at the 600px mobile breakpoint used elsewhere in the stylesheet, so the videos read as a nice grid on desktop and stack on phones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)