### PR TITLE
Add numpy to EdgeDraw demo deps so the docs WASM embed works

### DIFF
--- a/demos/edgedraw.py
+++ b/demos/edgedraw.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "marimo",
+#     "numpy==2.4.3",
 #     "wigglystuff==0.5.24",
 # ]
 # ///


### PR DESCRIPTION
## Problem

The [EdgeDraw reference docs page](https://koaning.github.io/wigglystuff/reference/edge-draw/) embeds a live marimo WASM (Pyodide) notebook — `demos/edgedraw.py`, loaded via `docs/assets/javascripts/demo-embed.js`. That notebook has a cell calling `widget.get_adjacency_matrix()`, and `EdgeDraw.get_adjacency_matrix()` does a runtime `import numpy` (`wigglystuff/edge_draw.py`). But the demo's PEP 723 `# /// script` dependency list omitted numpy, so the Pyodide sandbox never installed it and the cell broke with a numpy import error.

## Change

Add `numpy==2.4.3` to the demo's PEP 723 dependency block, placed between `marimo` and the `wigglystuff` pin to match the convention used by other demos (`dimensions.py`, `cube_widget.py`, …).

## Verification

`uv run marimo check demos/edgedraw.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)