### PR TITLE
docs: drop MuJoCo Physics from the Examples gallery

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -324,14 +324,6 @@ These notebooks show how to combine multiple widgets for more complex workflows.
 
 <div class="example-gallery">
 <div class="example-item">
-<a target="_blank" href="https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/mujoco_sim.py/server?utm_source=wigglystuff" class="example-img"><img src="assets/gallery/falling-balls.webp" alt="MuJoCo Falling Balls"></a>
-<div class="example-content">
-<div class="example-title">MuJoCo Physics</div>
-<div class="example-desc">Drive a headless MuJoCo physics sim with inline TangleSliders — drop semi-transparent bouncing balls and watch the rendered clip play back through mo.video. Runs on a molab server since MuJoCo is a native engine.</div>
-</div>
-<div class="gallery-links"><a target="_blank" href="https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/mujoco_sim.py/server?utm_source=wigglystuff">molab</a><a target="_blank" href="https://github.com/koaning/wigglystuff/blob/main/demos/mujoco_sim.py">Source</a></div>
-</div>
-<div class="example-item">
 <a target="_blank" href="https://molab.marimo.io/github/koaning/wigglystuff/blob/main/demos/dimensions.py?utm_source=wigglystuff" class="example-img"><img src="assets/gallery/dimensions.webp" alt="Dimensions"></a>
 <div class="example-content">
 <div class="example-title">Dimensions</div>


### PR DESCRIPTION
Removes the MuJoCo Physics tile from the Examples gallery in `docs/index.md`. The demo needs a native physics engine and only runs on a molab *server* runtime, so it breaks in the WASM-based molab embed we link from the docs. The demo notebook (`demos/mujoco_sim.py`) is kept in the repo — only the docs listing is dropped, and `Dimensions` becomes the first example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)