### PR TITLE
Add TangleSlider modifier scrubbing and scientific-notation entry (0.5.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.26] - 2026-08-18
+
+### Changed
+
+- `TangleSlider` scrubbing now responds to modifier keys while dragging: hold **Shift** for 10× coarser steps (cover a big range fast) and **Alt/Option** for 10× finer steps (dial in a precise value). Toggling a modifier mid-drag rebases the drag anchor so the value rescales smoothly instead of jumping. Applies to linear sliders only; discrete `steps` sliders are unchanged.
+- `TangleSlider` type-to-edit now accepts scientific notation (e.g. `2.5e-3`, `2.32e7`) and preserves exact values: typed values are clamped to `[min_value, max_value]` but no longer snapped to the `step` grid, so an entry like `2.5e-3` survives the round trip. The value is displayed as entered so the notation stays legible.
+
 ## [0.5.25] - 2026-08-12
 
 ### Added

--- a/demos/tangle.py
+++ b/demos/tangle.py
@@ -5,13 +5,13 @@
 #     "marimo>=0.19.4",
 #     "numpy==2.4.1",
 #     "pandas==2.3.3",
-#     "wigglystuff==0.5.11",
+#     "wigglystuff==0.5.26",
 # ]
 # ///
 
 import marimo
 
-__generated_with = "0.23.3"
+__generated_with = "0.23.16"
 app = marimo.App(width="medium")
 
 
@@ -37,7 +37,7 @@ def _(mo):
 
 @app.cell
 def _(TangleSlider, mo):
-    coffees = mo.ui.anywidget(TangleSlider(amount=10, min_value=0, step=1, suffix=" coffees", digits=0))
+    coffees = mo.ui.anywidget(TangleSlider(amount=10, min_value=0, max_value=10_000, step=1, suffix=" coffees", digits=0))
     price = mo.ui.anywidget(TangleSlider(amount=3.50, min_value=0.01, max_value=10, step=0.01, prefix="$", digits=2))
     return coffees, price
 
@@ -100,6 +100,44 @@ def _(c, mo, prob1, prob2):
         """),
         c
     ])
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Fine control & exact values
+
+    While dragging you can hold a modifier key to change the scrub speed:
+
+    - Hold **Shift** for 10&times; *coarser* steps &mdash; cover a big range fast.
+    - Hold **Alt / Option** for 10&times; *finer* steps &mdash; dial in a precise value.
+
+    Toggle the modifier mid-drag and the value rescales smoothly instead of
+    jumping. You can also **click** a slider to type an exact value, including
+    scientific notation like `2.5e-3`. Typed values are clamped to the bounds but
+    keep their exact value (they are *not* snapped to `step`).
+    """)
+    return
+
+
+@app.cell
+def _(TangleSlider, mo):
+    unit_cost = mo.ui.anywidget(
+        TangleSlider(amount=0.002, min_value=0, max_value=1, step=0.0001, prefix="$", digits=4)
+    )
+    return (unit_cost,)
+
+
+@app.cell(hide_code=True)
+def _(mo, unit_cost):
+    mo.md(f"""
+    Say each API call costs {unit_cost}.
+
+    - Hold **Alt/Option** and drag to nudge it by fractions of a cent.
+    - Click it and type `2.5e-3` to set an exact price &mdash; the `$` prefix
+      stays put and the value reads back as you typed it.
+    """)
     return
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.25"
+version = "0.5.26"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_e2e/test_tangle_browser.py
+++ b/tests/test_e2e/test_tangle_browser.py
@@ -76,6 +76,29 @@ def test_tangle_slider_click_to_type(start_marimo, page: Page):
 
 
 @pytest.mark.e2e
+def test_tangle_slider_scientific_notation_survives(start_marimo, page: Page):
+    """Typed scientific notation is kept exactly, not snapped to the step grid."""
+    url = start_marimo(NOTEBOOK)
+    page.goto(url, wait_until="networkidle")
+
+    page.wait_for_selector(".tangle-value", timeout=TIMEOUT)
+    widget = page.locator(".tangle-value").first
+    expect(widget).to_be_visible()
+
+    # The coffees slider has step=1; snapping would round 2.5e-3 to 0.
+    widget.click()
+    editor = page.locator(".tangle-input")
+    expect(editor).to_be_visible()
+    editor.fill("2.5e-3")
+    editor.press("Enter")
+
+    page.wait_for_timeout(200)
+    value = page.locator(".tangle-value").first
+    # The exact typed value is preserved and shown, not snapped away to 0.
+    expect(value).to_contain_text("2.5e-3")
+
+
+@pytest.mark.e2e
 def test_tangle_choice_renders_and_cycles(start_marimo, page: Page):
     """Test that TangleChoice renders and clicking cycles through choices."""
     url = start_marimo(NOTEBOOK)

--- a/wigglystuff/static/tangle-slider.js
+++ b/wigglystuff/static/tangle-slider.js
@@ -12,6 +12,10 @@ function render({model, el}) {
     let amount = model.get("amount");
     let steps = model.get("steps");
     let editing = false;
+    // Literal text the user last typed (e.g. "2.5e-3"). When set, the value is
+    // shown verbatim so scientific notation stays legible; cleared on any drag
+    // or Python-side change so those revert to toFixed(digits) formatting.
+    let lastTypedText = null;
 
     const container = document.createElement('div');
     container.classList.add("tangle-container");
@@ -30,6 +34,8 @@ function render({model, el}) {
             config.pixelsPerStep = model.get("pixels_per_step");
             amount = model.get("amount");
             steps = model.get("steps");
+            // A Python-side change supersedes any typed literal.
+            lastTypedText = null;
             // Ignore external syncs while the user is typing a value.
             if (!editing) renderValue();
         });
@@ -42,7 +48,8 @@ function render({model, el}) {
         element.style.color = '#0066cc';
         element.style.textDecoration = 'underline';
         element.style.cursor = 'ew-resize';
-        element.textContent = config.prefix + amount.toFixed(config.digits) + config.suffix;
+        const shown = lastTypedText !== null ? lastTypedText : amount.toFixed(config.digits);
+        element.textContent = config.prefix + shown + config.suffix;
         element.addEventListener('mousedown', startDragging);
         container.appendChild(element);
     }
@@ -58,17 +65,35 @@ function render({model, el}) {
         updateTimeout = setTimeout(updateModel, 50); // Debounce for 100ms
     }
 
+    // Modifier scaling for linear sliders: Shift = 10x coarser, Alt/Option =
+    // 10x finer (Alt wins if both are held). Discrete steps mode ignores this.
+    function modMultiplier(ev) {
+        if (ev.altKey) return 0.1;
+        if (ev.shiftKey) return 10;
+        return 1;
+    }
+
     function startDragging(e) {
         e.preventDefault();
         const element = e.target;
         element.style.cursor = 'grabbing';
-        const startX = e.clientX;
-        const startValue = parseFloat(element.textContent.replace(config.prefix, '').replace(config.suffix, ''));
+        // Anchor (startX/startValue) is mutable so we can rebase it when the
+        // modifier changes mid-drag, keeping the value from jumping.
+        let startX = e.clientX;
+        let startValue = amount;
+        let lastX = startX;
+        let curMult = 1;
         const startIndex = steps.length > 0 ? Math.max(0, steps.indexOf(amount)) : -1;
         let moved = false;
 
-        function onMouseMove(e) {
-            const deltaX = e.clientX - startX;
+        function applyMove(clientX, mult) {
+            if (mult !== curMult) {
+                // Rebase the anchor so future movement rescales from here.
+                startX = clientX;
+                startValue = amount;
+                curMult = mult;
+            }
+            const deltaX = clientX - startX;
             if (Math.abs(deltaX) > 3) moved = true;
             const pixelSteps = Math.floor(deltaX / config.pixelsPerStep);
             if (steps.length > 0) {
@@ -77,15 +102,29 @@ function render({model, el}) {
             } else {
                 amount = Math.max(config.minValue,
                                Math.min(config.maxValue,
-                                        startValue + pixelSteps * config.stepSize));
+                                        startValue + pixelSteps * config.stepSize * mult));
             }
             renderValue();
             debouncedUpdateModel();
         }
 
+        function onMouseMove(e) {
+            lastTypedText = null; // dragging supersedes any typed literal
+            lastX = e.clientX;
+            const mult = steps.length > 0 ? 1 : modMultiplier(e);
+            applyMove(e.clientX, mult);
+        }
+
+        function onKeyChange(e) {
+            if (steps.length > 0) return; // linear mode only
+            applyMove(lastX, modMultiplier(e));
+        }
+
         function onMouseUp() {
             document.removeEventListener('mousemove', onMouseMove);
             document.removeEventListener('mouseup', onMouseUp);
+            document.removeEventListener('keydown', onKeyChange);
+            document.removeEventListener('keyup', onKeyChange);
             element.style.cursor = 'ew-resize';
             // A click without a real drag enters edit mode (linear sliders only).
             if (!moved && steps.length === 0) {
@@ -98,18 +137,21 @@ function render({model, el}) {
 
         document.addEventListener('mousemove', onMouseMove);
         document.addEventListener('mouseup', onMouseUp);
+        document.addEventListener('keydown', onKeyChange);
+        document.addEventListener('keyup', onKeyChange);
     }
 
     function enterEditMode() {
         editing = true;
         const previous = amount;
+        const previousTypedText = lastTypedText;
         let finished = false;
 
         container.innerHTML = '';
         const input = document.createElement('input');
         input.type = 'text';
         input.className = 'tangle-input';
-        input.value = amount.toFixed(config.digits);
+        input.value = lastTypedText !== null ? lastTypedText : amount.toFixed(config.digits);
         // Match the value's look and keep it inline so the layout doesn't jump.
         input.style.color = '#0066cc';
         input.style.font = 'inherit';
@@ -130,18 +172,20 @@ function render({model, el}) {
             if (commit) {
                 const parsed = parseFloat(input.value);
                 if (!isNaN(parsed)) {
-                    let next = Math.max(config.minValue, Math.min(config.maxValue, parsed));
-                    // Snap to the step grid anchored at min_value, then re-clamp.
-                    if (config.stepSize > 0) {
-                        next = config.minValue + Math.round((next - config.minValue) / config.stepSize) * config.stepSize;
-                        next = Math.max(config.minValue, Math.min(config.maxValue, next));
-                    }
+                    // Clamp to bounds but do NOT snap to the step grid, so exact
+                    // values (incl. scientific notation like 2.5e-3) survive.
+                    const next = Math.max(config.minValue, Math.min(config.maxValue, parsed));
                     amount = next;
+                    // Show the literal text only when accepted unchanged; a
+                    // clamped value renders as the clamped number via toFixed.
+                    lastTypedText = next === parsed ? input.value.trim() : null;
                 } else {
                     amount = previous; // Non-numeric input: restore previous value.
+                    lastTypedText = previousTypedText;
                 }
             } else {
                 amount = previous; // Escape / blur cancels.
+                lastTypedText = previousTypedText;
             }
             renderValue();
             updateModel();


### PR DESCRIPTION
## What

Two quality-of-life features for `TangleSlider`, inspired by [marimo-team/marimo#10520](https://github.com/marimo-team/marimo/pull/10520):

### Modifier-key scrubbing (linear sliders)
- Hold **Shift** while dragging for 10× coarser steps.
- Hold **Alt/Option** for 10× finer steps.
- Toggling a modifier mid-drag rebases the drag anchor so the value rescales smoothly instead of jumping.
- Discrete `steps` sliders are unchanged.

### Scientific-notation type-to-edit
- The inline editor now accepts scientific notation (`2.5e-3`, `2.32e7`).
- Typed values are clamped to `[min_value, max_value]` but **no longer snapped to the `step` grid**, so exact entries survive the round trip (matching marimo's matrix behavior).
- The value is displayed as entered so the notation stays legible; drags and Python-side changes revert to `toFixed(digits)` formatting.

## Changes
- `wigglystuff/static/tangle-slider.js` — all interaction/display logic (no Python API changes).
- `demos/tangle.py` — new "Fine control & exact values" section with a `$`-prefixed example; pin bumped to `0.5.26`.
- `tests/test_e2e/test_tangle_browser.py` — e2e test locking the no-snap / scientific-notation behavior.
- `CHANGELOG.md`, `pyproject.toml` — 0.5.26 release.

## Tests
- `uv run pytest tests/ -k tangle --ignore=tests/test_e2e` → 22 passed.
- `uv run marimo check demos/tangle.py` → clean.

## Note
On-screen display currently shows the typed value **verbatim** (e.g. `10e-2` renders as `10e-2`, `.amount` is `0.1`). An alternative "normalized round-trip" display (show `toFixed` when it represents the value exactly, keep the literal only when rounding would lose it) was discussed — easy follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)