### PR TITLE
Release 0.5.27: Pip widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.5.27] - 2026-08-21
 
 ### Added
 

--- a/demos/inverse_turing_test.py
+++ b/demos/inverse_turing_test.py
@@ -6,7 +6,7 @@
 #     "scipy",
 #     "matplotlib",
 #     "anywidget",
-#     "wigglystuff==0.5.26",
+#     "wigglystuff==0.5.27",
 # ]
 # ///
 

--- a/demos/pip.py
+++ b/demos/pip.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "marimo",
-#     "wigglystuff==0.5.26",
+#     "wigglystuff==0.5.27",
 # ]
 # ///
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wigglystuff"
-version = "0.5.26"
+version = "0.5.27"
 description = "Collection of Anywidget Widgets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2979,7 +2979,7 @@ wheels = [
 
 [[package]]
 name = "wigglystuff"
-version = "0.5.26"
+version = "0.5.27"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
Stamps the **0.5.27** release.

## What's in it
- **Pip** widget (#329): wraps a widget and floats it in a Document Picture-in-Picture window above the notebook. Built on anywidget composition, hence the `anywidget>=0.11.0` minimum. All docs/gallery/reference/tests shipped with #329.

## Release mechanics
- `pyproject.toml` + `uv.lock`: `0.5.26 → 0.5.27`
- `CHANGELOG.md`: `## [Unreleased]` → `## [0.5.27] - 2026-08-21`
- Demo pin bumps to `wigglystuff==0.5.27` for `demos/pip.py` and `demos/inverse_turing_test.py` (both exercise `Pip`, so the old pin would fetch a release without it)

## Verification
- `from wigglystuff import Pip` imports cleanly
- `uv run marimo check demos/pip.py demos/inverse_turing_test.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)