### PR TITLE
Fix 'Marimo' capitalization to 'marimo' in docs and demo

### DIFF
--- a/demos/steamdeck.py
+++ b/demos/steamdeck.py
@@ -158,7 +158,7 @@ def _(
     set_index,
     set_last_ts,
 ):
-    # Marimo re-runs this cell on *any* traitlet change, including each
+    # marimo re-runs this cell on *any* traitlet change, including each
     # streamed speech token writing to `note`. Gate on `action_timestamp`
     # so we only commit when the user actually presses an action button.
     ts = annot_widget.action_timestamp

--- a/docs/index.md
+++ b/docs/index.md
@@ -321,7 +321,7 @@ The documentation for wigglystuff is designed for humans (via hosted marimo note
 
 Each widget links to a live demo on [molab](https://molab.marimo.io?utm_source=wigglystuff) where you can interact with and edit the notebook directly in your browser.
 
-## Marimo-only widgets
+## marimo-only widgets
 
 These are **marimo-only** display helpers — they render through marimo's mime protocol and reach into marimo's rendered DOM, so unlike the other widgets they don't run in plain Jupyter. They also appear in the gallery above.
 


### PR DESCRIPTION
The marimo brand is stylized lowercase, but two spots in the shipped package capitalized it. Fixes the `## Marimo-only widgets` heading in `docs/index.md` (now matching the "marimo-only" body text below it) and a code comment in `demos/steamdeck.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)