### PR TITLE
Render ProgressBar as a rich terminal bar in script mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `ProgressBar` now mirrors its progress into a fancy animated terminal bar when
+  used in **script mode** (outside a marimo/jupyter notebook) and the optional
+  [`rich`](https://github.com/Textualize/rich) library is installed. No loop
+  changes are needed — each `bar.value` assignment updates a spinner + colored
+  bar + percentage + `M/N` count + time-remaining display, and the bar tracks the
+  value in both directions. Install `rich` with `pip install rich`; without it,
+  or inside a notebook, behavior is unchanged.
+
 ## [0.5.31] - 2026-09-01
 
 ### Added

--- a/demos/progressbar.py
+++ b/demos/progressbar.py
@@ -17,6 +17,13 @@ def _(mo):
     ## ProgressBar
 
     The `ProgressBar` widget gives you a progress bar that works across notebook runtimes without needing ipywidgets. You can update it from another cell in marimo, which the built-in progress bar does not allow.
+
+    The same widget also has a trick up its sleeve: run this notebook as a script
+    (with [`rich`](https://github.com/Textualize/rich) installed) and the bars
+    render as fancy animated progress bars **in the terminal** instead. marimo
+    knows which mode it is in via `mo.app_meta().mode` (`"edit"`/`"run"` in the
+    browser, `"script"` on the command line), and `ProgressBar` uses the same
+    signal to pick its renderer automatically. No code changes needed either way.
     """)
     return
 
@@ -71,6 +78,56 @@ def _(slim_bar, time):
     for _ in range(50):
         time.sleep(0.05)
         slim_bar.widget.value += 1
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Moving backward
+
+    `value` is absolute, so the bar can also *retreat* — handy when a step fails
+    and you have to retry. In the browser the fill shrinks; run as a script and
+    the rich bar shrinks the same way.
+    """)
+    return
+
+
+@app.cell
+def _(ProgressBar, mo):
+    retry_bar = mo.ui.anywidget(ProgressBar(value=0, max_value=30, color="#f59e0b"))
+    retry_bar
+    return (retry_bar,)
+
+
+@app.cell
+def _(retry_bar, time):
+    # climb to 20, stumble back to 10, then finish
+    forward = list(range(0, 21))
+    back = list(range(19, 9, -1))
+    finish = list(range(11, 31))
+    retry_bar.widget.value = 0
+    for _v in forward + back + finish:
+        time.sleep(0.06)
+        retry_bar.widget.value = _v
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Script mode
+
+    Nothing above changes for the terminal — the loops in this notebook drive
+    `.value`, and when the notebook runs as a script those exact assignments
+    animate a rich bar in the terminal (spinner, colored bar, percentage, count
+    and a time-remaining estimate). `rich` must be installed for this
+    (`pip install rich`); then run:
+
+    ```
+    uv run --with rich python demos/progressbar.py
+    ```
+    """)
     return
 
 

--- a/docs/reference/progress-bar.md
+++ b/docs/reference/progress-bar.md
@@ -26,6 +26,36 @@ See also: [HTMLRefreshWidget](html-refresh.md) for status text updated in place 
 [AnnotationWidget](annotation.md) for the labeling queue that bar is often counting, and
 [PlaySlider](play-slider.md) when the value should be driven by the reader instead.
 
+## Script mode: a rich terminal bar
+
+The same `ProgressBar` works outside a notebook too. When the code runs as a
+script — either a plain Python file or a marimo notebook run with
+`uv run notebook.py` — and the optional [`rich`](https://github.com/Textualize/rich)
+library is installed, each `bar.value` assignment is mirrored into a fancy
+animated bar in the terminal: a spinner, a bar colored from `color`, a
+percentage, an `M/N` count (shown when `show_text` is `True`) and a
+time-remaining estimate. Because the value is applied as an absolute position,
+the terminal bar moves backward too if `value` decreases.
+
+marimo distinguishes these modes with `mo.app_meta().mode` (`"edit"`/`"run"` in
+the browser, `"script"` on the command line), and `ProgressBar` keys off the
+same signal — so one notebook shows the browser widget when edited and the rich
+bar when executed. No changes to your loop are needed either way:
+
+```python
+import time
+from wigglystuff import ProgressBar
+
+bar = ProgressBar(max_value=50)
+for i in range(51):
+    bar.value = i
+    time.sleep(0.05)
+```
+
+Install rich with `pip install rich`. If `rich` is not installed, or the code
+runs inside a notebook editor, this behaves exactly as before — nothing extra is
+rendered.
+
 ::: wigglystuff.html.ProgressBar
 
 ### Synced traitlets

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,61 @@
+"""Tests for the ProgressBar widget's script-mode rich terminal mirror."""
+
+import sys
+
+import pytest
+
+from wigglystuff import ProgressBar
+from wigglystuff import html
+
+
+def test_defaults_and_construction():
+    bar = ProgressBar()
+    assert bar.value == 0
+    assert bar.max_value == 100
+    assert bar.color == "#22c55e"
+    assert bar.show_text is True
+
+
+def test_script_mode_mirrors_value_including_backward(monkeypatch):
+    pytest.importorskip("rich")
+    monkeypatch.setattr(html, "_in_notebook", lambda: False)
+
+    bar = ProgressBar(max_value=50)
+    assert bar._rich_enabled is True
+    assert bar._rich_progress is None  # created lazily
+
+    bar.value = 10
+    assert bar._rich_progress is not None
+    assert bar._rich_progress.tasks[0].completed == 10
+
+    bar.value = 40
+    assert bar._rich_progress.tasks[0].completed == 40
+
+    # rich uses an absolute `completed`, so the bar can also move backward.
+    bar.value = 5
+    assert bar._rich_progress.tasks[0].completed == 5
+
+    bar._stop_rich()
+    assert bar._rich_progress is None
+
+
+def test_notebook_mode_has_no_terminal_mirror(monkeypatch):
+    monkeypatch.setattr(html, "_in_notebook", lambda: True)
+
+    bar = ProgressBar()
+    assert bar._rich_enabled is False
+
+    bar.value = 42  # must not create a terminal display
+    assert bar._rich_progress is None
+
+
+def test_missing_rich_is_a_noop(monkeypatch):
+    monkeypatch.setattr(html, "_in_notebook", lambda: False)
+    # Setting the module to None makes `import rich` raise ImportError.
+    monkeypatch.setitem(sys.modules, "rich", None)
+
+    bar = ProgressBar()
+    assert bar._rich_enabled is False
+
+    bar.value = 7  # must not raise even though rich is unavailable
+    assert bar._rich_progress is None

--- a/wigglystuff/html.py
+++ b/wigglystuff/html.py
@@ -7,6 +7,36 @@ import anywidget
 import traitlets
 
 
+def _in_notebook() -> bool:
+    """Return True when a notebook front-end (marimo or jupyter) is present.
+
+    Used to decide whether a widget should also render into the terminal.
+    Anything that is not a notebook counts as "script mode" (including a bare
+    ``python`` REPL, where a rich terminal bar is perfectly welcome).
+    """
+    try:
+        import marimo as mo
+
+        if mo.running_in_notebook():
+            return True
+    except Exception:
+        pass
+    try:
+        from IPython import get_ipython
+
+        ip = get_ipython()
+        if ip is not None and ip.__class__.__name__ == "ZMQInteractiveShell":
+            return True
+    except Exception:
+        pass
+    return False
+
+
+# rich allows only one live display per process, so we track the active one and
+# retire it before starting the next (lets sequential ProgressBars each render).
+_active_rich_progress = None
+
+
 class ImageRefreshWidget(anywidget.AnyWidget):
     """A widget that displays an image and refreshes when the source changes.
 
@@ -104,6 +134,12 @@ class ProgressBar(anywidget.AnyWidget):
     One of the main benefits of this utility is that you have a progress bar
     that doesn't depend on ipywidgets while you still have something that
     works across notebook projects.
+
+    When used in **script mode** (outside a marimo/jupyter notebook) and the
+    optional ``rich`` library is installed, the same progress is mirrored into a
+    fancy animated bar in the terminal. This needs no changes to your loop code:
+    just keep setting ``.value``. Install rich with ``pip install rich``. If
+    ``rich`` is not installed, or you are in a notebook, this does nothing extra.
 
     Attributes:
         value (int): The current progress value. Defaults to 0.
@@ -209,3 +245,74 @@ class ProgressBar(anywidget.AnyWidget):
         self.show_text = show_text
         self.width = width
         self.height = height
+
+        # In script mode, mirror progress into a rich terminal bar (if rich is
+        # installed). The display is created lazily on the first value change.
+        self._rich_progress = None
+        self._rich_task = None
+        self._rich_enabled = False
+        if not _in_notebook():
+            try:
+                import rich  # noqa: F401 -- availability probe only
+
+                self._rich_enabled = True
+                self.observe(self._on_value_change, names=["value", "max_value"])
+            except Exception:
+                self._rich_enabled = False
+
+    def _ensure_rich(self) -> None:
+        if self._rich_progress is not None:
+            return
+        from rich.progress import (
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            SpinnerColumn,
+            TaskProgressColumn,
+            TimeRemainingColumn,
+        )
+
+        global _active_rich_progress
+        # Only one rich live display can be active at a time; retire the previous.
+        if _active_rich_progress is not None:
+            try:
+                _active_rich_progress.stop()
+            except Exception:
+                pass
+            _active_rich_progress = None
+
+        columns = [SpinnerColumn(style=self.color), BarColumn(complete_style=self.color)]
+        if self.show_text:
+            columns += [TaskProgressColumn(), MofNCompleteColumn(), TimeRemainingColumn()]
+        try:
+            self._rich_progress = Progress(*columns, transient=False)
+            self._rich_progress.start()
+        except Exception:
+            self._rich_progress = None
+            self._rich_enabled = False
+            return
+        _active_rich_progress = self._rich_progress
+        self._rich_task = self._rich_progress.add_task("", total=self.max_value)
+        import atexit
+
+        atexit.register(self._stop_rich)
+
+    def _on_value_change(self, change) -> None:
+        if not self._rich_enabled:
+            return
+        self._ensure_rich()
+        if self._rich_progress is None:
+            return
+        self._rich_progress.update(
+            self._rich_task, completed=self.value, total=self.max_value
+        )
+
+    def _stop_rich(self) -> None:
+        global _active_rich_progress
+        if self._rich_progress is not None:
+            try:
+                self._rich_progress.stop()
+            finally:
+                if _active_rich_progress is self._rich_progress:
+                    _active_rich_progress = None
+                self._rich_progress = None


### PR DESCRIPTION
When a `ProgressBar` is used outside a notebook — a plain script, or a marimo notebook run as a script — and the optional `rich` library is installed (`pip install rich`), each `.value` assignment is now mirrored into an animated terminal bar with a color-matched spinner, colored bar, percentage, M/N count and a time-remaining estimate. Script vs. notebook is detected via marimo's own signal (the same one behind `mo.app_meta().mode`) plus an IPython-kernel check, and `rich` is imported lazily so behavior is completely unchanged when it is absent or inside a notebook. Because `.value` maps to rich's absolute `completed`, the terminal bar can also move backward, matching the browser widget. The `demos/progressbar.py` notebook now doubles as a script demo (including a bar that steps backward), and docs, changelog, and a new `tests/test_html.py` cover the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)